### PR TITLE
feat: Internal Hook Array Support + Codepen Examples in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.0] - 2025-07-14
+
+### Added
+- **Array Support for All Hooks**: All utility hooks now support arrays of elements with per-element logic
+  - `useClasses(elements, { className: (el) => condition })` - Apply classes with element-specific functions
+  - `useStyles(elements, { property: (el) => value })` - Apply styles with element-specific functions  
+  - `useAttributes(elements, { attr: (el) => value })` - Set attributes with element-specific functions
+  - `useEvents(elements, { event: handler })` - Attach events to multiple elements (already supported)
+
+### Enhanced
+- **Graceful Nil Handling**: All hooks now handle `null`/`undefined` elements gracefully with warnings instead of throwing errors
+- **Memory Optimization**: WeakMap-based per-element tracking for automatic garbage collection
+- **API Consistency**: All hooks follow the same patterns for array support and mixed condition types
+
+### Technical
+- Added `isHTMLElementArray` type guard for consistent array validation
+- Enhanced test coverage with 290 total passing tests
+- Improved documentation with array support examples
+
+## [0.3.0] - 2025-07-08
+
+### Added
+- **Browser Script Tag Support**: HookTML can now be imported via `<script>` tag for direct HTML usage
+  - Global build available at `index.global.js` - exposes `HookTML` global object
+  - Browser build available at `index.browser.js` - optimized for browser environments
+  - CDN-ready distribution for quick prototyping and development
+
+### Enhanced
+- **Multiple Export Formats**: Package now supports Node.js, browser, and global script environments
+- **Improved Package Structure**: Clear separation between different build targets
+
+### Technical
+- Added `index.global.js` and `index.browser.js` build outputs
+- Updated package.json exports for better module resolution
+- Enhanced build pipeline for multiple distribution formats 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - 2025-07-14
+## [0.4.0] - 2025-07-24
 
 ### Added
 - **Array Support for All Hooks**: All utility hooks now support arrays of elements with per-element logic
-  - `useClasses(elements, { className: (el) => condition })` - Apply classes with element-specific functions
-  - `useStyles(elements, { property: (el) => value })` - Apply styles with element-specific functions  
-  - `useAttributes(elements, { attr: (el) => value })` - Set attributes with element-specific functions
-  - `useEvents(elements, { event: handler })` - Attach events to multiple elements (already supported)
+  - `useClasses(elements, { className: (el, index) => condition })` - Apply classes with element-specific functions
+  - `useStyles(elements, { property: (el, index) => value })` - Apply styles with element-specific functions  
+  - `useAttributes(elements, { attr: (el, index) => value })` - Set attributes with element-specific functions
+  - `useEvents(elements, { event: (event, index) => handler })` - Event handlers receive both event and element index
+- **Manual Dependencies**: All utility hooks now accept optional deps array for explicit reactivity control
+  - `useClasses(elements, classMap, [signal])` - Control when classes update based on signals
+  - `useStyles(elements, styleMap, [signal])` - Control when styles update based on signals
+  - `useAttributes(elements, attrMap, [signal])` - Control when attributes update based on signals
+  - `useEvents(elements, eventMap, [signal])` - Control when event handlers update based on signals
 
 ### Enhanced
 - **Graceful Nil Handling**: All hooks now handle `null`/`undefined` elements gracefully with warnings instead of throwing errors

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ HookTML is a JavaScript library that lets you add interactive behavior to HTML w
 - 🧹 **Automatic cleanup** - No manual lifecycle management
 - 🚀 **Progressive enhancement** - Perfect for server-rendered apps
 
+## 🚀 Try It Live
+
+See HookTML in action with these interactive examples:
+
+- **[Currency Converter](https://codepen.io/shroy/pen/bNVbjVP)** - Real-time reactive updates with signals
+- **[Todo App](https://codepen.io/...)** - Component communication and state management  
+- **[Modal Dialog](https://codepen.io/...)** - Advanced patterns with lifecycle hooks
+- **[Tabs Component](https://codepen.io/...)** - Child element coordination
+
+*All examples use the CDN - no build step required! Fork and experiment.*
+
 ## Quick Example
 
 ```html

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ HookTML is a JavaScript library that lets you add interactive behavior to HTML w
 See HookTML in action with these interactive examples:
 
 - **[Currency Converter](https://codepen.io/shroy/pen/bNVbjVP)** - Real-time reactive updates with signals
-- **[Todo App](https://codepen.io/...)** - Component communication and state management  
+- **[Todo App](https://codepen.io/shroy/pen/VYvZBmB)** - Component communication and state management  
 - **[Modal Dialog](https://codepen.io/...)** - Advanced patterns with lifecycle hooks
 - **[Tabs Component](https://codepen.io/...)** - Child element coordination
 

--- a/README.md
+++ b/README.md
@@ -644,7 +644,7 @@ useClasses(button, {
 });
 
 // Set inline styles
-useStyle(modal, {
+useStyles(modal, {
   maxHeight: `${window.innerHeight * 0.8}px`,
   zIndex: 100
 });
@@ -656,7 +656,38 @@ useAttributes(toggle, {
 });
 ```
 
-These hooks make your styling logic more readable and maintainable. See the [API Reference](#api-reference) section for complete details on these utility hooks.
+#### Array Support
+
+All styling hooks also support arrays of elements with per-element logic using functions:
+
+```js
+// Apply different styles to each element
+useClasses(tabButtons, {
+  active: (btn) => selectedTab.value === btn.dataset.id,
+  disabled: isGloballyDisabled  // Mix with direct values/signals
+});
+
+useStyles(cardElements, {
+  backgroundColor: (card) => card.dataset.theme,
+  transform: (card) => `scale(${card.dataset.scale || 1})`
+});
+
+useAttributes(menuItems, {
+  'aria-selected': (item) => activeItem.value === item.dataset.id ? 'true' : 'false',
+  'tabindex': (item) => item.dataset.disabled ? '-1' : '0'
+});
+
+// Events work with arrays too (handlers receive event object)
+useEvents([button1, button2], {
+  click: (event) => handleClick(event.target.dataset.action)
+});
+
+useEvents(document, {
+  keydown: (event) => event.key === 'Escape' && closeModal()
+});
+```
+
+These hooks make your styling logic more readable and maintainable, whether working with single elements or multiple elements. See the [API Reference](#api-reference) section for complete details on these utility hooks.
 
 ### FOUC Prevention
 
@@ -694,10 +725,10 @@ The `data-hooktml-cloak` attribute is removed automatically once behavior is rea
 
 | Hook | Description |
 |------|-------------|
-| `useEvents(el, eventMap)` | Bind multiple events declaratively |
-| `useStyle(el, styleObject)` | Apply inline styles |
-| `useAttributes(el, attrMap)` | Set DOM attributes |
-| `useClasses(el, classMap)` | Toggle class names based on conditions |
+| `useEvents(el, eventMap)` | Bind multiple events declaratively. Supports arrays of elements and EventTargets (HTMLElement, Document, Window) |
+| `useStyles(el, styleObject)` | Apply inline styles. Supports arrays with per-element functions |
+| `useAttributes(el, attrMap)` | Set DOM attributes. Supports arrays with per-element functions |
+| `useClasses(el, classMap)` | Toggle class names based on conditions. Supports arrays with per-element functions |
 | `useChildren(el, prefix)` | Query child elements with a specific prefix, returning both singular and plural keys for consistent access |
 
 ### Component Return Values

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ See HookTML in action with these interactive examples:
 - **[Currency Converter](https://codepen.io/shroy/pen/bNVbjVP)** - Real-time reactive updates with signals
 - **[Todo App](https://codepen.io/shroy/pen/VYvZBmB)** - Component communication and state management  
 - **[Modal Dialog](https://codepen.io/shroy/pen/qEOdmXe)** - Handling external triggers
-- **[Tabs Component](examples/tabs.html)** - Array support and element collections
+- **[Tabs Component](https://codepen.io/shroy/pen/vENKaQN)** - Array support and element collections
 - **[Counter](https://codepen.io/shroy/pen/myeJmXr)** - Purely using a hook
 
 *All examples use the CDN - no build step required! Fork and experiment.*

--- a/examples/currency-converter.html
+++ b/examples/currency-converter.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://unpkg.com/hooktml@latest/dist/hooktml.min.js"></script>
+  <title>Currency Converter - HookTML Example</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 500px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      background: #f8fafc;
+    }
+
+    .CurrencyConverter {
+      background: white;
+      padding: 2rem;
+      border-radius: 12px;
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    }
+
+    .converter-group {
+      margin-bottom: 1.5rem;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 0.5rem;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    input,
+    select {
+      width: 100%;
+      padding: 0.75rem;
+      border: 2px solid #e5e7eb;
+      border-radius: 8px;
+      font-size: 1rem;
+      transition: border-color 0.2s;
+    }
+
+    input:focus,
+    select:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+
+    .converter-result {
+      background: #f3f4f6;
+      padding: 1rem;
+      border-radius: 8px;
+      text-align: center;
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: #059669;
+      min-height: 1.5rem;
+    }
+
+    .currency-row {
+      display: grid;
+      grid-template-columns: 2fr 1fr;
+      gap: 1rem;
+      align-items: end;
+    }
+
+    h1 {
+      text-align: center;
+      color: #1f2937;
+      margin-bottom: 2rem;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>💱 Currency Converter</h1>
+
+  <div class="Converter">
+    <div class="converter-group">
+      <label for="amount">Amount</label>
+      <input type="number" id="amount" converter-amount placeholder="Enter amount" value="100" min="0" step="0.01">
+    </div>
+
+    <div class="converter-group">
+      <div class="currency-row">
+        <div>
+          <label for="from-currency">From</label>
+          <select id="from-currency" converter-from>
+            <option value="USD">🇺🇸 USD - US Dollar</option>
+            <option value="EUR">🇪🇺 EUR - Euro</option>
+            <option value="GBP">🇬🇧 GBP - British Pound</option>
+            <option value="JPY">🇯🇵 JPY - Japanese Yen</option>
+          </select>
+        </div>
+        <div>
+          <label for="to-currency">To</label>
+          <select id="to-currency" converter-to>
+            <option value="USD">🇺🇸 USD</option>
+            <option value="EUR" selected>🇪🇺 EUR</option>
+            <option value="GBP">🇬🇧 GBP</option>
+            <option value="JPY">🇯🇵 JPY</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <div class="converter-group">
+      <label>Converted Amount</label>
+      <div converter-result class="converter-result">85.00 EUR</div>
+    </div>
+  </div>
+
+  <script>
+    // Simple exchange rates (in real app, fetch from API)
+    const exchangeRates = {
+      USD: { EUR: 0.85, GBP: 0.73, JPY: 110, USD: 1 },
+      EUR: { USD: 1.18, GBP: 0.86, JPY: 129, EUR: 1 },
+      GBP: { USD: 1.37, EUR: 1.16, JPY: 150, GBP: 1 },
+      JPY: { USD: 0.009, EUR: 0.0078, GBP: 0.0067, JPY: 1 }
+    };
+
+    const Converter = (el, props) => {
+      const { amount, from, to, result } = props.children;
+
+      // Reactive signals for state
+      const amountValue = HookTML.signal(parseFloat(amount.value) || 0);
+      const fromCurrency = HookTML.signal(from.value);
+      const toCurrency = HookTML.signal(to.value);
+
+      // Computed signal for conversion
+      const convertedAmount = HookTML.computed(() => {
+        const amt = amountValue.value;
+        const fromCur = fromCurrency.value;
+        const toCur = toCurrency.value;
+
+        if (amt === 0) return '0.00';
+
+        const rate = exchangeRates[fromCur]?.[toCur] || 1;
+        const converted = amt * rate;
+
+        return converted.toLocaleString('en-US', {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2
+        });
+      });
+
+      // Update display when conversion changes
+      HookTML.useEffect(() => {
+        result.textContent = `${convertedAmount.value} ${toCurrency.value}`;
+      }, [convertedAmount, toCurrency]);
+
+      // Listen to input changes
+      HookTML.useEvents(amount, {
+        input: (e) => {
+          amountValue.value = parseFloat(e.target.value) || 0;
+        }
+      });
+
+      HookTML.useEvents(from, {
+        change: (e) => {
+          fromCurrency.value = e.target.value;
+        }
+      });
+
+      HookTML.useEvents(to, {
+        change: (e) => {
+          toCurrency.value = e.target.value;
+        }
+      });
+    };
+
+    // Register the component
+    HookTML.registerComponent(Converter);
+
+    // Start HookTML
+    HookTML.start();
+  </script>
+</body>
+
+</html>

--- a/examples/modal-dialog.html
+++ b/examples/modal-dialog.html
@@ -1,0 +1,463 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://unpkg.com/hooktml@latest/dist/hooktml.min.js"></script>
+  <title>Modal Dialog - HookTML Example</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      max-width: 800px;
+      margin: 2rem auto;
+      padding: 0 1rem;
+      background: #f8fafc;
+    }
+
+    .demo-section {
+      background: white;
+      padding: 2rem;
+      border-radius: 12px;
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+      margin-bottom: 2rem;
+    }
+
+    h1 {
+      text-align: center;
+      color: #1f2937;
+      margin-bottom: 2rem;
+    }
+
+    h2 {
+      color: #374151;
+      margin-bottom: 1rem;
+    }
+
+    .button-group {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    button {
+      padding: 0.75rem 1.5rem;
+      border: none;
+      border-radius: 8px;
+      font-size: 1rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+
+    .btn-primary {
+      background: #3b82f6;
+      color: white;
+    }
+
+    .btn-primary:hover {
+      background: #2563eb;
+      transform: translateY(-1px);
+    }
+
+    .btn-success {
+      background: #10b981;
+      color: white;
+    }
+
+    .btn-success:hover {
+      background: #059669;
+      transform: translateY(-1px);
+    }
+
+    .btn-danger {
+      background: #ef4444;
+      color: white;
+    }
+
+    .btn-danger:hover {
+      background: #dc2626;
+      transform: translateY(-1px);
+    }
+
+    .btn-secondary {
+      background: #6b7280;
+      color: white;
+    }
+
+    .btn-secondary:hover {
+      background: #4b5563;
+      transform: translateY(-1px);
+    }
+
+    /* Dialog Styling */
+    dialog {
+      border: none;
+      border-radius: 12px;
+      padding: 0;
+      box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+      max-width: 500px;
+      width: 90vw;
+    }
+
+    dialog::backdrop {
+      background: rgba(0, 0, 0, 0.5);
+    }
+
+    [modal-header] {
+      padding: 1.5rem 2rem 1rem;
+      border-bottom: 1px solid #e5e7eb;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    [modal-title] {
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: #1f2937;
+      margin: 0;
+    }
+
+    .modal-close {
+      background: none;
+      border: none;
+      font-size: 1.5rem;
+      cursor: pointer;
+      color: #6b7280;
+      padding: 0.25rem;
+      border-radius: 4px;
+      width: 2rem;
+      height: 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .modal-close:hover {
+      background: #f3f4f6;
+      color: #374151;
+    }
+
+    [modal-body] {
+      padding: 1.5rem 2rem;
+    }
+
+    [modal-footer] {
+      padding: 1rem 2rem 1.5rem;
+      border-top: 1px solid #e5e7eb;
+      display: flex;
+      gap: 1rem;
+      justify-content: flex-end;
+    }
+
+    .form-group {
+      margin-bottom: 1.5rem;
+    }
+
+    label {
+      display: block;
+      margin-bottom: 0.5rem;
+      font-weight: 600;
+      color: #374151;
+    }
+
+    input,
+    textarea,
+    select {
+      width: 100%;
+      padding: 0.75rem;
+      border: 2px solid #e5e7eb;
+      border-radius: 8px;
+      font-size: 1rem;
+      transition: border-color 0.2s;
+    }
+
+    input:focus,
+    textarea:focus,
+    select:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+
+    textarea {
+      resize: vertical;
+      min-height: 100px;
+    }
+
+    .demo-info {
+      background: #e7f3ff;
+      padding: 1rem;
+      border-radius: 8px;
+      border-left: 4px solid #3b82f6;
+      margin-top: 1rem;
+    }
+
+    .demo-info p {
+      margin: 0;
+      color: #1e40af;
+      line-height: 1.5;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>🪟 Modal Dialog Example</h1>
+
+  <div class="demo-section">
+    <h2>Interactive Modal Dialogs</h2>
+    <p>Click the buttons below to open different types of modal dialogs enhanced with HookTML:</p>
+
+    <div class="button-group">
+      <button class="btn-primary" use-modal-trigger="info-modal">ℹ️ Info Dialog</button>
+      <button class="btn-success" use-modal-trigger="contact-modal">📧 Contact Form</button>
+      <button class="btn-danger" use-modal-trigger="confirm-modal">⚠️ Confirm Action</button>
+    </div>
+
+    <div class="demo-info">
+      <p><strong>Features:</strong> Native HTML5 dialog element enhanced with HookTML. Uses
+        <code>use-modal-trigger</code> hook for declarative triggers and <code>modal-modal-id</code> component props for
+        identification. Includes backdrop click closing, escape key handling, focus management, and automatic cleanup.
+      </p>
+    </div>
+  </div>
+
+  <!-- Info Modal -->
+  <dialog class="Modal" modal-modal-id="info-modal">
+    <div modal-header>
+      <h3 modal-title>About HookTML</h3>
+      <button modal-close class="modal-close">×</button>
+    </div>
+    <div modal-body>
+      <p><strong>HookTML</strong> is a JavaScript library that lets you add interactive behavior to HTML without
+        sacrificing control over your markup.</p>
+      <p>Key features include:</p>
+      <ul>
+        <li>HTML-first development approach</li>
+        <li>Functional composition with hooks</li>
+        <li>Reactive signals for state management</li>
+        <li>Automatic cleanup and lifecycle management</li>
+        <li>Progressive enhancement friendly</li>
+      </ul>
+    </div>
+    <div modal-footer>
+      <button modal-close class="btn-secondary">Close</button>
+      <button class="btn-primary">Learn More</button>
+    </div>
+  </dialog>
+
+  <!-- Contact Form Modal -->
+  <dialog class="Modal" modal-modal-id="contact-modal">
+    <div modal-header>
+      <h3 modal-title>Contact Us</h3>
+      <button modal-close class="modal-close">×</button>
+    </div>
+    <div modal-body>
+      <form modal-form>
+        <div class="form-group">
+          <label for="name">Name</label>
+          <input type="text" id="name" name="name" required>
+        </div>
+        <div class="form-group">
+          <label for="email">Email</label>
+          <input type="email" id="email" name="email" required>
+        </div>
+        <div class="form-group">
+          <label for="subject">Subject</label>
+          <select id="subject" name="subject">
+            <option value="general">General Inquiry</option>
+            <option value="support">Support</option>
+            <option value="feedback">Feedback</option>
+            <option value="bug">Bug Report</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="message">Message</label>
+          <textarea id="message" name="message" placeholder="How can we help you?" required></textarea>
+        </div>
+      </form>
+    </div>
+    <div modal-footer>
+      <button modal-close class="btn-secondary">Cancel</button>
+      <button modal-submit class="btn-success">Send Message</button>
+    </div>
+  </dialog>
+
+  <!-- Confirmation Modal -->
+  <dialog class="Modal" modal-modal-id="confirm-modal">
+    <div modal-header>
+      <h3 modal-title>Confirm Action</h3>
+      <button modal-close class="modal-close">×</button>
+    </div>
+    <div modal-body>
+      <p>Are you sure you want to delete this item? This action cannot be undone.</p>
+      <p><strong>Warning:</strong> All associated data will be permanently removed from the system.</p>
+    </div>
+    <div modal-footer>
+      <button modal-close class="btn-secondary">Cancel</button>
+      <button modal-confirm class="btn-danger">Delete Item</button>
+    </div>
+  </dialog>
+
+  <script>
+    // Destructure HookTML functions
+    const { signal, useEffect, useEvents, registerComponent, registerHook, start } = HookTML;
+
+    // Store modal registry for communication between triggers and modals
+    const modalRegistry = new Map();
+
+    // Modal Trigger Hook
+    const useModalTrigger = (el, props) => {
+      const modalId = props.value; // The modal ID to trigger
+
+      useEvents(el, {
+        click: () => {
+          const modal = modalRegistry.get(modalId);
+          if (modal) {
+            modal.open();
+          }
+        }
+      });
+    };
+
+    // Modal Dialog Component
+    const Modal = (el, props) => {
+
+      const { closes, submit, confirm, form, header, body, footer, title } = props.children;
+      const modalId = props.modalId; // Now using proper HookTML props
+
+      // State
+      const isOpen = signal(false);
+
+      // Open modal function
+      const openModal = () => {
+        el.showModal();
+        isOpen.value = true;
+
+        // Focus management - focus first focusable element
+        const focusable = el.querySelector('input, button, textarea, select');
+        if (focusable) {
+          setTimeout(() => focusable.focus(), 100);
+        }
+      };
+
+      // Close modal function  
+      const closeModal = () => {
+        // Clear form data if there's a form
+        if (form) {
+          form.reset();
+        }
+        el.close();
+        isOpen.value = false;
+      };
+
+      // Register this modal in the global registry
+      if (modalId) {
+        modalRegistry.set(modalId, {
+          open: openModal,
+          close: closeModal,
+          element: el
+        });
+      }
+
+      // Handle close buttons (multiple possible)
+      if (closes && closes.length) {
+        closes.forEach(button => {
+          useEvents(button, {
+            click: (e) => {
+              e.preventDefault();
+              closeModal();
+            }
+          });
+        });
+      }
+
+      // Handle form submission
+      if (submit) {
+        useEvents(submit, {
+          click: (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (form && form.checkValidity()) {
+              alert('Form submitted successfully!');
+              closeModal();
+            } else if (form) {
+              form.reportValidity();
+            }
+          }
+        });
+      }
+
+      // Handle form submit event (in case form is submitted via enter key)
+      if (form) {
+        useEvents(form, {
+          submit: (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (form.checkValidity()) {
+              alert('Form submitted successfully!');
+              closeModal();
+            } else {
+              form.reportValidity();
+            }
+          }
+        });
+      }
+
+      // Handle confirmation
+      if (confirm) {
+        useEvents(confirm, {
+          click: (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            alert('Item deleted successfully!');
+            closeModal();
+          }
+        });
+      }
+
+      // Handle backdrop click (native dialog behavior)
+      useEvents(el, {
+        click: (e) => {
+          // Close if clicking on the dialog backdrop
+          if (e.target === el) {
+            closeModal();
+          }
+        }
+      });
+
+      // Handle escape key (enhanced)
+      const handleEscape = (e) => {
+        if (e.key === 'Escape' && isOpen.value) {
+          closeModal();
+        }
+      };
+
+      document.addEventListener('keydown', handleEscape);
+
+      // Cleanup function
+      return () => {
+        if (isOpen.value) {
+          closeModal();
+        }
+        // Remove from registry
+        if (modalId) {
+          modalRegistry.delete(modalId);
+        }
+        // Remove escape key listener
+        document.removeEventListener('keydown', handleEscape);
+      };
+    };
+
+    // Register the hook and component
+    registerHook(useModalTrigger);
+    registerComponent(Modal);
+
+    // Start HookTML
+    start({
+      debug: false
+    });
+  </script>
+</body>
+
+</html>

--- a/examples/modal-dialog.html
+++ b/examples/modal-dialog.html
@@ -218,6 +218,8 @@
       <p><strong>Features:</strong> Native HTML5 dialog element enhanced with HookTML. Uses
         <code>use-modal-trigger</code> hook for declarative triggers and <code>modal-modal-id</code> component props for
         identification. Includes backdrop click closing, escape key handling, focus management, and automatic cleanup.
+        <strong>New:</strong> Demonstrates HookTML's array support - multiple close buttons handled with a single
+        <code>useEvents(closeButtons, {...})</code> call instead of manual loops.
       </p>
     </div>
   </div>
@@ -300,7 +302,6 @@
   </dialog>
 
   <script>
-    // Destructure HookTML functions
     const { signal, useEffect, useEvents, registerComponent, registerHook, start } = HookTML;
 
     // Store modal registry for communication between triggers and modals
@@ -321,10 +322,17 @@
     };
 
     // Modal Dialog Component
-    const Modal = (el, props) => {
-
-      const { closes, submit, confirm, form, header, body, footer, title } = props.children;
-      const modalId = props.modalId; // Now using proper HookTML props
+    const Modal = (el, { modalId, children }) => {
+      const {
+        header,
+        body,
+        footer,
+        title,
+        form,
+        closes,
+        submit,
+        confirm,
+      } = children;
 
       // State
       const isOpen = signal(false);
@@ -360,61 +368,51 @@
         });
       }
 
-      // Handle close buttons (multiple possible)
-      if (closes && closes.length) {
-        closes.forEach(button => {
-          useEvents(button, {
-            click: (e) => {
-              e.preventDefault();
-              closeModal();
-            }
-          });
-        });
-      }
+      // Handle close buttons (multiple possible) - Using HookTML array support
+      useEvents(closes, {
+        click: (e) => {
+          e.preventDefault();
+          closeModal();
+        }
+      });
 
       // Handle form submission
-      if (submit) {
-        useEvents(submit, {
-          click: (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            if (form && form.checkValidity()) {
-              alert('Form submitted successfully!');
-              closeModal();
-            } else if (form) {
-              form.reportValidity();
-            }
+      useEvents(submit, {
+        click: (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (form && form.checkValidity()) {
+            alert('Form submitted successfully!');
+            closeModal();
+          } else if (form) {
+            form.reportValidity();
           }
-        });
-      }
+        }
+      });
 
       // Handle form submit event (in case form is submitted via enter key)
-      if (form) {
-        useEvents(form, {
-          submit: (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            if (form.checkValidity()) {
-              alert('Form submitted successfully!');
-              closeModal();
-            } else {
-              form.reportValidity();
-            }
+      useEvents(form, {
+        submit: (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          if (form.checkValidity()) {
+            alert('Form submitted successfully!');
+            closeModal();
+          } else {
+            form.reportValidity();
           }
-        });
-      }
+        }
+      });
 
       // Handle confirmation
-      if (confirm) {
-        useEvents(confirm, {
-          click: (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            alert('Item deleted successfully!');
-            closeModal();
-          }
-        });
-      }
+      useEvents(confirm, {
+        click: (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          alert('Item deleted successfully!');
+          closeModal();
+        }
+      });
 
       // Handle backdrop click (native dialog behavior)
       useEvents(el, {
@@ -426,14 +424,14 @@
         }
       });
 
-      // Handle escape key (enhanced)
-      const handleEscape = (e) => {
-        if (e.key === 'Escape' && isOpen.value) {
-          closeModal();
-        }
-      };
 
-      document.addEventListener('keydown', handleEscape);
+      useEvents(document, {
+        keydown: (e) => {
+          if (e.key === 'Escape' && isOpen.value) {
+            closeModal();
+          }
+        }
+      });
 
       // Cleanup function
       return () => {
@@ -444,8 +442,6 @@
         if (modalId) {
           modalRegistry.delete(modalId);
         }
-        // Remove escape key listener
-        document.removeEventListener('keydown', handleEscape);
       };
     };
 
@@ -454,9 +450,7 @@
     registerComponent(Modal);
 
     // Start HookTML
-    start({
-      debug: false
-    });
+    start({ debug: false });
   </script>
 </body>
 

--- a/examples/simple-counter.html
+++ b/examples/simple-counter.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://unpkg.com/hooktml@latest/dist/hooktml.min.js"></script>
   <title>Simple Counter - HookTML Example</title>
   <style>
     body {
@@ -140,8 +141,8 @@
     </div>
   </div>
 
-  <script type="module">
-    import { HookTML, signal, useEffect, useEvents, registerHook, useChildren } from '../src/index.js';
+  <script>
+    const { signal, useEffect, useEvents, registerHook, useChildren } = HookTML;
 
     const useCounter = (el, props) => {
       const initialValue = props.initial ? parseInt(props.initial) : 0;
@@ -179,11 +180,7 @@
 
     registerHook(useCounter);
 
-    HookTML.start({
-      debug: true
-    }).then(() => {
-      console.log('🎉 HookTML Counter Example loaded successfully!');
-    });
+    HookTML.start({ debug: false })
   </script>
 </body>
 

--- a/examples/tabs.html
+++ b/examples/tabs.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://unpkg.com/hooktml@latest/dist/hooktml.min.js"></script>
+  <title>Tabs Component - HookTML Example</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      max-width: 800px;
+      margin: 50px auto;
+      padding: 20px;
+      background: #f8fafc;
+    }
+
+    .tabs-container {
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+      overflow: hidden;
+    }
+
+    .tab-buttons {
+      display: flex;
+      background: #f1f5f9;
+      border-bottom: 1px solid #e2e8f0;
+    }
+
+    .tab-button {
+      flex: 1;
+      padding: 16px 24px;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      font-size: 16px;
+      font-weight: 500;
+      color: #64748b;
+      transition: all 0.2s ease;
+      border-bottom: 3px solid transparent;
+    }
+
+    .tab-button:hover {
+      background: rgba(59, 130, 246, 0.05);
+      color: #3b82f6;
+    }
+
+    .tab-button.active {
+      background: white;
+      color: #3b82f6;
+      border-bottom-color: #3b82f6;
+    }
+
+    .tab-panels {
+      min-height: 300px;
+    }
+
+    .tab-panel {
+      padding: 32px;
+      display: none;
+      animation: fadeIn 0.3s ease;
+    }
+
+    .tab-panel.active {
+      display: block;
+    }
+
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+        transform: translateY(10px);
+      }
+
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .demo-content {
+      line-height: 1.6;
+      color: #374151;
+    }
+
+    .demo-content h3 {
+      margin-top: 0;
+      color: #1f2937;
+    }
+
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 16px;
+      margin-top: 20px;
+    }
+
+    .demo-card {
+      padding: 16px;
+      background: #f8fafc;
+      border-radius: 8px;
+      border-left: 4px solid #3b82f6;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Tabs Component</h1>
+  <p>This example showcases HookTML's array support for hooks, demonstrating how collections of elements are handled
+    gracefully.</p>
+
+  <div class="tabs-container Tabs">
+    <div class="tab-buttons">
+      <button class="tab-button active" tabs-button data-tab="0">Overview</button>
+      <button class="tab-button" tabs-button data-tab="1">Features</button>
+      <button class="tab-button" tabs-button data-tab="2">Documentation</button>
+    </div>
+
+    <div class="tab-panels">
+      <div class="tab-panel active" tabs-panel data-panel="0">
+        <div class="demo-content">
+          <h3>HookTML Overview</h3>
+          <p>HookTML brings reactive programming to vanilla HTML with zero build steps. This tabs component demonstrates
+            several key features:</p>
+          <ul>
+            <li><strong>Array Support:</strong> <code>useEvents</code> handles multiple tab buttons effortlessly</li>
+            <li><strong>Reactive Classes:</strong> <code>useClasses</code> manages active states across collections</li>
+            <li><strong>Graceful Handling:</strong> Hooks work seamlessly with empty arrays and nil values</li>
+            <li><strong>Signal-driven:</strong> State changes propagate automatically to all connected elements</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="tab-panel" tabs-panel data-panel="1">
+        <div class="demo-content">
+          <h3>Key Features</h3>
+          <div class="demo-grid">
+            <div class="demo-card">
+              <h4>Zero Build</h4>
+              <p>No webpack, no babel, no build step. Just include the script and start building.</p>
+            </div>
+            <div class="demo-card">
+              <h4>Array Support</h4>
+              <p>All hooks work with single elements or arrays. Handle collections naturally.</p>
+            </div>
+            <div class="demo-card">
+              <h4>Reactive Signals</h4>
+              <p>Built-in reactivity system keeps your UI in sync with state changes.</p>
+            </div>
+            <div class="demo-card">
+              <h4>Graceful Errors</h4>
+              <p>Nil values and edge cases are handled automatically. No defensive programming needed.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="tab-panel" tabs-panel data-panel="2">
+        <div class="demo-content">
+          <h3>Tabs Implementation</h3>
+          <p>This component showcases HookTML's built-in children system and array support:</p>
+          <pre style="background: #f1f5f9; padding: 16px; border-radius: 8px; overflow-x: auto;"><code>// Children automatically collected via tabs-* attributes
+  const { buttons, panels } = props.children;
+
+  // Single useEvents call for all buttons (array support)
+  useEvents(buttons, {
+    click: (event) => {
+      const tabIndex = parseInt(event.target.dataset.tab);
+      activeTab.value = tabIndex;
+    }
+  });
+
+  // Function conditions receive each element individually
+  useClasses(buttons, {
+    active: (element) => {
+      const tabIndex = parseInt(element.dataset.tab);
+      return activeTab.value === tabIndex;
+    }
+  });
+
+  useClasses(panels, {
+    active: (element) => {
+      const panelIndex = parseInt(element.dataset.panel);
+      return activeTab.value === panelIndex;
+    }
+  });</code></pre>
+          <p><strong>Key Benefits:</strong></p>
+          <ul>
+            <li>Children auto-collected via <code>tabs-*</code> attributes</li>
+            <li>Single <code>useEvents</code> call handles all buttons via array support</li>
+            <li>Function conditions receive each element individually</li>
+            <li>No manual queries or defensive checks required</li>
+            <li>Automatic cleanup when component unmounts</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const { signal, computed, useEvents, useClasses, registerComponent, start } = HookTML;
+
+    const Tabs = (element, props) => {
+      const activeTab = signal(0);
+
+      const { buttons, panels } = props.children;
+
+      useEvents(buttons, {
+        click: (event, index) => {
+          activeTab.value = index;
+        }
+      });
+
+      useClasses(buttons, {
+        active: (element, index) => activeTab.value === index
+      }, [activeTab]);
+
+      useClasses(panels, {
+        active: (element, index) => activeTab.value === index
+      }, [activeTab])
+    }
+
+    registerComponent(Tabs);
+    start({ debug: true });
+  </script>
+</body>
+
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooktml",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A reactive HTML component library with hooks-based lifecycle management",
   "main": "index.js",
   "type": "module",

--- a/src/hooks/useAttributes.js
+++ b/src/hooks/useAttributes.js
@@ -6,7 +6,8 @@ import {
   isNonEmptyArray,
   isNonEmptyObject,
   isNotNil,
-  isSignal
+  isSignal,
+  isEmptyArray
 } from '../utils/type-guards.js'
 import { useEffect } from '../core/hookContext.js'
 import { tryCatch } from '../utils/try-catch.js'
@@ -21,7 +22,13 @@ import { logger } from '../utils/logger.js'
 export const useAttributes = (elementOrElements, attrMap) => {
 
   if (isNil(elementOrElements)) {
-    logger.warn('[HookTML] useAttributes called with null/undefined element, skipping attribute application')
+    logger.warn('[HookTML] useAttributes called with null/undefined element, skipping attribute setting')
+    return () => { } // Return no-op cleanup function
+  }
+
+  // Handle empty arrays gracefully
+  if (isEmptyArray(elementOrElements)) {
+    logger.warn('[HookTML] useAttributes called with empty array, skipping attribute setting')
     return () => { } // Return no-op cleanup function
   }
 

--- a/src/hooks/useAttributes.js
+++ b/src/hooks/useAttributes.js
@@ -22,13 +22,13 @@ import { logger } from '../utils/logger.js'
 export const useAttributes = (elementOrElements, attrMap) => {
 
   if (isNil(elementOrElements)) {
-    logger.warn('[HookTML] useAttributes called with null/undefined element, skipping attribute setting')
+    logger.info('[HookTML] useAttributes called with null/undefined element, skipping attribute setting')
     return () => { } // Return no-op cleanup function
   }
 
   // Handle empty arrays gracefully
   if (isEmptyArray(elementOrElements)) {
-    logger.warn('[HookTML] useAttributes called with empty array, skipping attribute setting')
+    logger.info('[HookTML] useAttributes called with empty array, skipping attribute setting')
     return () => { } // Return no-op cleanup function
   }
 

--- a/src/hooks/useClasses.js
+++ b/src/hooks/useClasses.js
@@ -1,53 +1,71 @@
-/**
- * Hook for conditionally applying CSS classes to an element
- * @param {HTMLElement|null|undefined} element - The element to apply classes to (or null/undefined)
- * @param {Record<string, boolean|{value: boolean, subscribe: Function}>} classMap - Object mapping class names to boolean conditions or signals
- * @returns {Function} Cleanup function that removes all event listeners
- */
-import { isHTMLElement, isNonEmptyArray, isNonEmptyObject, isSignal, isNil } from '../utils/type-guards.js'
+import { isHTMLElement, isHTMLElementArray, isNonEmptyArray, isNonEmptyObject, isSignal, isNil, isFunction } from '../utils/type-guards.js'
 import { useEffect } from '../core/hookContext.js'
 import { logger } from '../utils/logger.js'
 
-export const useClasses = (element, classMap) => {
+/**
+ * Hook for conditionally applying CSS classes to an element or array of elements
+ * @param {HTMLElement|HTMLElement[]|null|undefined} elementOrElements - The element(s) to apply classes to (or null/undefined)
+ * @param {Record<string, boolean|{value: boolean, subscribe: Function}|Function>} classMap - Object mapping class names to boolean conditions, signals, or functions
+ * @returns {Function} Cleanup function that removes all event listeners
+ */
+export const useClasses = (elementOrElements, classMap) => {
 
-  if (isNil(element)) {
+  if (isNil(elementOrElements)) {
     logger.warn('[HookTML] useClasses called with null/undefined element, skipping class application')
     return () => { } // Return no-op cleanup function
   }
 
-  if (!isHTMLElement(element)) {
-    throw new Error('[HookTML] useClasses requires an HTMLElement as first argument')
+  // Normalize input to array
+  const elements = isHTMLElementArray(elementOrElements) ? elementOrElements : [elementOrElements]
+
+  if (elements.some(element => !isHTMLElement(element))) {
+    throw new Error('[HookTML] useClasses requires HTMLElement(s) as first argument')
   }
 
   if (!isNonEmptyObject(classMap)) {
     throw new Error('[HookTML] useClasses requires a non-empty object mapping class names to boolean conditions')
   }
 
-  // Extract signals from classMap for effect dependencies
+  // Extract signals from classMap for effect dependencies (ignore functions)
   const signalDeps = Object.values(classMap).filter(isSignal)
 
-  // Track which classes we've added for cleanup
-  const addedClasses = new Set()
+  // Track which classes we've added per element for cleanup using WeakMap
+  const addedClassesPerElement = new WeakMap()
+
+  // Function to evaluate a condition for a specific element
+  const evaluateCondition = (condition, element) => {
+    if (isFunction(condition)) {
+      return Boolean(condition(element))
+    } else if (isSignal(condition)) {
+      return Boolean(condition.value)
+    } else {
+      return Boolean(condition)
+    }
+  }
 
   // Function to update classes based on current conditions
   const updateClasses = () => {
-    // Clear previously added classes first
-    addedClasses.forEach(className => {
-      element.classList.remove(className)
-    })
-    addedClasses.clear()
-
-    // Apply classes based on current conditions
-    Object.entries(classMap).forEach(([className, condition]) => {
-      // Handle both boolean and signal values
-      const isActive = isSignal(condition)
-        ? condition.value
-        : Boolean(condition)
-
-      if (isActive) {
-        element.classList.add(className)
-        addedClasses.add(className)
+    elements.forEach(element => {
+      let addedClasses = addedClassesPerElement.get(element)
+      if (!addedClasses) {
+        addedClasses = new Set()
+        addedClassesPerElement.set(element, addedClasses)
       }
+
+      // Clear previously added classes first
+      addedClasses.forEach(className => {
+        element.classList.remove(className)
+      })
+      addedClasses.clear()
+
+      Object.entries(classMap).forEach(([className, condition]) => {
+        const isActive = evaluateCondition(condition, element)
+
+        if (isActive) {
+          element.classList.add(className)
+          addedClasses.add(className)
+        }
+      })
     })
   }
 
@@ -63,9 +81,14 @@ export const useClasses = (element, classMap) => {
 
   // Return cleanup function
   return () => {
-    addedClasses.forEach(className => {
-      element.classList.remove(className)
+    elements.forEach(element => {
+      const addedClasses = addedClassesPerElement.get(element)
+      if (addedClasses) {
+        addedClasses.forEach(className => {
+          element.classList.remove(className)
+        })
+        addedClasses.clear()
+      }
     })
-    addedClasses.clear()
   }
 } 

--- a/src/hooks/useClasses.js
+++ b/src/hooks/useClasses.js
@@ -1,13 +1,20 @@
 /**
  * Hook for conditionally applying CSS classes to an element
- * @param {HTMLElement} element - The element to apply classes to
+ * @param {HTMLElement|null|undefined} element - The element to apply classes to (or null/undefined)
  * @param {Record<string, boolean|{value: boolean, subscribe: Function}>} classMap - Object mapping class names to boolean conditions or signals
  * @returns {Function} Cleanup function that removes all event listeners
  */
-import { isHTMLElement, isNonEmptyArray, isNonEmptyObject, isSignal } from '../utils/type-guards.js'
+import { isHTMLElement, isNonEmptyArray, isNonEmptyObject, isSignal, isNil } from '../utils/type-guards.js'
 import { useEffect } from '../core/hookContext.js'
+import { logger } from '../utils/logger.js'
 
 export const useClasses = (element, classMap) => {
+
+  if (isNil(element)) {
+    logger.warn('[HookTML] useClasses called with null/undefined element, skipping class application')
+    return () => { } // Return no-op cleanup function
+  }
+
   if (!isHTMLElement(element)) {
     throw new Error('[HookTML] useClasses requires an HTMLElement as first argument')
   }
@@ -34,7 +41,7 @@ export const useClasses = (element, classMap) => {
     Object.entries(classMap).forEach(([className, condition]) => {
       // Handle both boolean and signal values
       const isActive = isSignal(condition)
-        ? condition.value 
+        ? condition.value
         : Boolean(condition)
 
       if (isActive) {

--- a/src/hooks/useClasses.js
+++ b/src/hooks/useClasses.js
@@ -1,4 +1,13 @@
-import { isHTMLElement, isHTMLElementArray, isNonEmptyArray, isNonEmptyObject, isSignal, isNil, isFunction } from '../utils/type-guards.js'
+import {
+  isHTMLElement,
+  isHTMLElementArray,
+  isNonEmptyArray,
+  isNonEmptyObject,
+  isSignal,
+  isNil,
+  isFunction,
+  isEmptyArray
+} from '../utils/type-guards.js'
 import { useEffect } from '../core/hookContext.js'
 import { logger } from '../utils/logger.js'
 
@@ -12,6 +21,12 @@ export const useClasses = (elementOrElements, classMap) => {
 
   if (isNil(elementOrElements)) {
     logger.warn('[HookTML] useClasses called with null/undefined element, skipping class application')
+    return () => { } // Return no-op cleanup function
+  }
+
+  // Handle empty arrays gracefully  
+  if (isEmptyArray(elementOrElements)) {
+    logger.warn('[HookTML] useClasses called with empty array, skipping class application')
     return () => { } // Return no-op cleanup function
   }
 

--- a/src/hooks/useClasses.js
+++ b/src/hooks/useClasses.js
@@ -20,13 +20,13 @@ import { logger } from '../utils/logger.js'
 export const useClasses = (elementOrElements, classMap) => {
 
   if (isNil(elementOrElements)) {
-    logger.warn('[HookTML] useClasses called with null/undefined element, skipping class application')
+    logger.info('[HookTML] useClasses called with null/undefined element, skipping class application')
     return () => { } // Return no-op cleanup function
   }
 
   // Handle empty arrays gracefully  
   if (isEmptyArray(elementOrElements)) {
-    logger.warn('[HookTML] useClasses called with empty array, skipping class application')
+    logger.info('[HookTML] useClasses called with empty array, skipping class application')
     return () => { } // Return no-op cleanup function
   }
 

--- a/src/hooks/useEvents.js
+++ b/src/hooks/useEvents.js
@@ -1,14 +1,20 @@
 /**
  * Hook for adding event listeners with automatic cleanup
- * @param {EventTarget} element - The element to attach events to (HTMLElement, Document, or Window)
+ * @param {EventTarget|null|undefined} element - The element to attach events to (HTMLElement, Document, or Window, or null/undefined)
  * @param {Record<string, EventListener|{value: EventListener, subscribe: Function}>} eventMap - Object mapping event names to handlers or signals containing handlers
  * @returns {Function} Cleanup function that removes all event listeners
  */
-import { isEventTarget, isNonEmptyObject, isFunction, isSignal } from '../utils/type-guards.js'
+import { isEventTarget, isNonEmptyObject, isFunction, isSignal, isNil } from '../utils/type-guards.js'
 import { useEffect } from '../core/hookContext.js'
 import { logger } from '../utils/logger.js'
 
 export const useEvents = (element, eventMap) => {
+  // Handle null/undefined elements gracefully
+  if (isNil(element)) {
+    logger.warn('[HookTML] useEvents called with null/undefined element, skipping event registration')
+    return () => { } // Return no-op cleanup function
+  }
+
   if (!isEventTarget(element)) {
     throw new Error('[HookTML] useEvents requires an EventTarget (HTMLElement, Document, or Window) as first argument')
   }

--- a/src/hooks/useEvents.js
+++ b/src/hooks/useEvents.js
@@ -14,10 +14,10 @@ import { logger } from '../utils/logger.js'
 /**
  * Hook for adding event listeners with automatic cleanup
  * @param {EventTarget|EventTarget[]|null|undefined} elementOrElements - The element(s) to attach events to (HTMLElement, Document, Window, array of these, or null/undefined)
- * @param {Record<string, EventListener|{value: EventListener, subscribe: Function}>} eventMap - Object mapping event names to handlers or signals containing handlers
+ * @param {Record<string, (event: Event, index: number) => void | {value: (event: Event, index: number) => void, subscribe: Function}>} eventMap - Object mapping event names to handlers or signals containing handlers
  * @returns {Function} Cleanup function that removes all event listeners
  */
-export const useEvents = (elementOrElements, eventMap) => {
+export const useEvents = (elementOrElements, eventMap, deps = []) => {
 
   if (isNil(elementOrElements)) {
     logger.info('[HookTML] useEvents called with null/undefined element, skipping event registration')
@@ -42,7 +42,8 @@ export const useEvents = (elementOrElements, eventMap) => {
     throw new Error('[HookTML] useEvents requires a non-empty object mapping event names to listeners')
   }
 
-  const signalDeps = Object.values(eventMap).filter(isSignal)
+  const implicitDeps = Object.values(eventMap).filter(isSignal)
+  const allDeps = implicitDeps.concat(deps);
 
   const currentHandlers = new Map()
 
@@ -54,7 +55,7 @@ export const useEvents = (elementOrElements, eventMap) => {
     })
     currentHandlers.clear()
 
-    Object.entries(eventMap).forEach(([eventName, handlerOrSignal]) => {
+    const validHandlers = Object.entries(eventMap).filter(([eventName, handlerOrSignal]) => {
       const handler = isSignal(handlerOrSignal)
         ? handlerOrSignal.value
         : handlerOrSignal
@@ -64,20 +65,31 @@ export const useEvents = (elementOrElements, eventMap) => {
         return
       }
 
-      elements.forEach(element => {
-        element.addEventListener(eventName, handler)
-      })
+      return [eventName, handler]
+    })
 
-      currentHandlers.set(eventName, handler)
+    elements.forEach((element, index) => {
+      validHandlers.forEach(([eventName, handler]) => {
+        /**
+         * @param {Event} event
+         */
+        const handlerWithIndex = (event) => {
+          handler(event, index)
+        }
+
+        element.addEventListener(eventName, handlerWithIndex)
+
+        currentHandlers.set(eventName, handlerWithIndex)
+      })
     })
   }
 
   updateEventListeners()
 
-  if (isNonEmptyArray(signalDeps)) {
+  if (isNonEmptyArray(allDeps)) {
     useEffect(() => {
       updateEventListeners()
-    }, signalDeps)
+    }, allDeps)
   }
 
   return () => {

--- a/src/hooks/useEvents.js
+++ b/src/hooks/useEvents.js
@@ -1,13 +1,13 @@
+import { isEventTarget, isEventTargetArray, isNonEmptyObject, isFunction, isSignal, isNil } from '../utils/type-guards.js'
+import { useEffect } from '../core/hookContext.js'
+import { logger } from '../utils/logger.js'
+
 /**
  * Hook for adding event listeners with automatic cleanup
  * @param {EventTarget|EventTarget[]|null|undefined} elementOrElements - The element(s) to attach events to (HTMLElement, Document, Window, array of these, or null/undefined)
  * @param {Record<string, EventListener|{value: EventListener, subscribe: Function}>} eventMap - Object mapping event names to handlers or signals containing handlers
  * @returns {Function} Cleanup function that removes all event listeners
  */
-import { isEventTarget, isEventTargetArray, isNonEmptyObject, isFunction, isSignal, isNil } from '../utils/type-guards.js'
-import { useEffect } from '../core/hookContext.js'
-import { logger } from '../utils/logger.js'
-
 export const useEvents = (elementOrElements, eventMap) => {
   // Handle null/undefined elements gracefully
   if (isNil(elementOrElements)) {

--- a/src/hooks/useEvents.js
+++ b/src/hooks/useEvents.js
@@ -20,12 +20,12 @@ import { logger } from '../utils/logger.js'
 export const useEvents = (elementOrElements, eventMap) => {
 
   if (isNil(elementOrElements)) {
-    logger.warn('[HookTML] useEvents called with null/undefined element, skipping event registration')
+    logger.info('[HookTML] useEvents called with null/undefined element, skipping event registration')
     return () => { } // Return no-op cleanup function
   }
 
   if (isEmptyArray(elementOrElements)) {
-    logger.warn('[HookTML] useEvents called with empty array, skipping event registration')
+    logger.info('[HookTML] useEvents called with empty array, skipping event registration')
     return () => { } // Return no-op cleanup function
   }
 

--- a/src/hooks/useEvents.js
+++ b/src/hooks/useEvents.js
@@ -1,16 +1,16 @@
 /**
  * Hook for adding event listeners with automatic cleanup
- * @param {HTMLElement} element - The element to attach events to
+ * @param {EventTarget} element - The element to attach events to (HTMLElement, Document, or Window)
  * @param {Record<string, EventListener|{value: EventListener, subscribe: Function}>} eventMap - Object mapping event names to handlers or signals containing handlers
  * @returns {Function} Cleanup function that removes all event listeners
  */
-import { isHTMLElement, isNonEmptyObject, isFunction, isSignal } from '../utils/type-guards.js'
+import { isEventTarget, isNonEmptyObject, isFunction, isSignal } from '../utils/type-guards.js'
 import { useEffect } from '../core/hookContext.js'
 import { logger } from '../utils/logger.js'
 
 export const useEvents = (element, eventMap) => {
-  if (!isHTMLElement(element)) {
-    throw new Error('[HookTML] useEvents requires an HTMLElement as first argument')
+  if (!isEventTarget(element)) {
+    throw new Error('[HookTML] useEvents requires an EventTarget (HTMLElement, Document, or Window) as first argument')
   }
 
   if (!isNonEmptyObject(eventMap)) {

--- a/src/hooks/useStyles.js
+++ b/src/hooks/useStyles.js
@@ -22,12 +22,12 @@ import { logger } from '../utils/logger.js'
 export const useStyles = (elementOrElements, styleMap) => {
 
   if (isNil(elementOrElements)) {
-    logger.warn('[HookTML] useStyles called with null/undefined element, skipping style application')
+    logger.info('[HookTML] useStyles called with null/undefined element, skipping style application')
     return () => { } // Return no-op cleanup function
   }
 
   if (isEmptyArray(elementOrElements)) {
-    logger.warn('[HookTML] useStyles called with empty array, skipping style application')
+    logger.info('[HookTML] useStyles called with empty array, skipping style application')
     return () => { } // Return no-op cleanup function
   }
 

--- a/src/tests/useAttributes.spec.js
+++ b/src/tests/useAttributes.spec.js
@@ -211,4 +211,202 @@ describe('useAttributes', () => {
       expect(element.hasAttribute('data-visible')).toBe(false)
     })
   })
+
+  describe('Array Support', () => {
+    let elements
+
+    beforeEach(() => {
+      elements = [
+        document.createElement('div'),
+        document.createElement('div'),
+        document.createElement('div')
+      ]
+
+      elements.forEach((el, index) => {
+        el.setAttribute('data-index', index.toString())
+        el.setAttribute('data-type', ['primary', 'secondary', 'tertiary'][index])
+        el.setAttribute('data-value', `value-${index}`)
+      })
+    })
+
+    it('should handle array of elements with function conditions', () => {
+      useAttributes(elements, {
+        'data-id': (el) => `element-${el.dataset.index}`,
+        'aria-label': (el) => `${el.dataset.type} button`,
+        'data-active': (el) => el.dataset.index === '1' ? 'true' : 'false'
+      })
+
+      expect(elements[0].getAttribute('data-id')).toBe('element-0')
+      expect(elements[0].getAttribute('aria-label')).toBe('primary button')
+      expect(elements[0].getAttribute('data-active')).toBe('false')
+
+      expect(elements[1].getAttribute('data-id')).toBe('element-1')
+      expect(elements[1].getAttribute('aria-label')).toBe('secondary button')
+      expect(elements[1].getAttribute('data-active')).toBe('true')
+
+      expect(elements[2].getAttribute('data-id')).toBe('element-2')
+      expect(elements[2].getAttribute('aria-label')).toBe('tertiary button')
+      expect(elements[2].getAttribute('data-active')).toBe('false')
+    })
+
+    it('should handle mixed function, signal, and direct value conditions', () => {
+      const globalRole = { value: 'button', subscribe: () => { } }
+
+      useAttributes(elements, {
+        'data-id': (el) => `element-${el.dataset.index}`,
+        'role': globalRole,
+        'data-static': 'static-value'
+      })
+
+      elements.forEach((el, index) => {
+        expect(el.getAttribute('data-id')).toBe(`element-${index}`)
+        expect(el.getAttribute('role')).toBe('button')
+        expect(el.getAttribute('data-static')).toBe('static-value')
+      })
+    })
+
+    it('should handle null values to remove attributes', () => {
+      elements.forEach(el => {
+        el.setAttribute('data-remove', 'will-be-removed')
+        el.setAttribute('data-keep', 'will-be-kept')
+      })
+
+      useAttributes(elements, {
+        'data-remove': (el) => el.dataset.index === '1' ? null : 'kept',
+        'data-keep': 'updated',
+        'data-new': (el) => `new-${el.dataset.index}`
+      })
+
+      expect(elements[0].getAttribute('data-remove')).toBe('kept')
+      expect(elements[0].getAttribute('data-keep')).toBe('updated')
+      expect(elements[0].getAttribute('data-new')).toBe('new-0')
+
+      expect(elements[1].hasAttribute('data-remove')).toBe(false)
+      expect(elements[1].getAttribute('data-keep')).toBe('updated')
+      expect(elements[1].getAttribute('data-new')).toBe('new-1')
+
+      expect(elements[2].getAttribute('data-remove')).toBe('kept')
+      expect(elements[2].getAttribute('data-keep')).toBe('updated')
+      expect(elements[2].getAttribute('data-new')).toBe('new-2')
+    })
+
+    it('should cleanup attributes correctly for each element', () => {
+      elements.forEach(el => {
+        el.setAttribute('data-original', 'original-value')
+        el.setAttribute('data-untouched', 'untouched')
+      })
+
+      const cleanup = useAttributes(elements, {
+        'data-original': (el) => `modified-${el.dataset.index}`,
+        'data-new': (el) => `new-${el.dataset.index}`
+      })
+
+      elements.forEach((el, index) => {
+        expect(el.getAttribute('data-original')).toBe(`modified-${index}`)
+        expect(el.getAttribute('data-new')).toBe(`new-${index}`)
+        expect(el.getAttribute('data-untouched')).toBe('untouched')
+      })
+
+      cleanup()
+
+      elements.forEach(el => {
+        expect(el.getAttribute('data-original')).toBe('original-value') // Restored
+        expect(el.hasAttribute('data-new')).toBe(false) // Removed
+        expect(el.getAttribute('data-untouched')).toBe('untouched') // Unchanged
+      })
+    })
+
+    it('should handle single element passed as array', () => {
+      const singleElementArray = [elements[0]]
+
+      useAttributes(singleElementArray, {
+        'data-test': 'test-value',
+        'aria-label': (el) => `element-${el.dataset.index}`
+      })
+
+      expect(elements[0].getAttribute('data-test')).toBe('test-value')
+      expect(elements[0].getAttribute('aria-label')).toBe('element-0')
+      expect(elements[1].hasAttribute('data-test')).toBe(false)
+      expect(elements[2].hasAttribute('data-test')).toBe(false)
+    })
+
+    it('should maintain backward compatibility with single elements', () => {
+      useAttributes(elements[0], {
+        'data-test': 'single-value',
+        'aria-label': 'single-label'
+      })
+
+      expect(elements[0].getAttribute('data-test')).toBe('single-value')
+      expect(elements[0].getAttribute('aria-label')).toBe('single-label')
+      expect(elements[1].hasAttribute('data-test')).toBe(false)
+      expect(elements[2].hasAttribute('data-test')).toBe(false)
+    })
+
+    it('should handle null/undefined in array gracefully', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => { })
+
+      const cleanupNull = useAttributes(null, { 'data-test': 'test' })
+      const cleanupUndefined = useAttributes(undefined, { 'data-test': 'test' })
+
+      expect(consoleSpy).toHaveBeenCalledTimes(2)
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('useAttributes called with null/undefined element'))
+
+      expect(typeof cleanupNull).toBe('function')
+      expect(typeof cleanupUndefined).toBe('function')
+
+      expect(() => cleanupNull()).not.toThrow()
+      expect(() => cleanupUndefined()).not.toThrow()
+
+      consoleSpy.mockRestore()
+    })
+
+    it('should throw error for invalid elements in array', () => {
+      const invalidArray = [elements[0], 'not-an-element', elements[1]]
+
+      expect(() => useAttributes(invalidArray, { 'data-test': 'test' })).toThrow('[HookTML] useAttributes requires HTMLElement(s) as first argument')
+    })
+
+    it('should handle complex function conditions with conditional logic', () => {
+      useAttributes(elements, {
+        'data-computed': (el) => {
+          const index = parseInt(el.dataset.index)
+          return index % 2 === 0 ? 'even' : 'odd'
+        },
+        'aria-selected': (el) => el.dataset.type === 'secondary' ? 'true' : 'false',
+        'data-priority': (el) => {
+          const priorities = { primary: 'high', secondary: 'medium', tertiary: 'low' }
+          return priorities[el.dataset.type]
+        }
+      })
+
+      expect(elements[0].getAttribute('data-computed')).toBe('even')
+      expect(elements[0].getAttribute('aria-selected')).toBe('false')
+      expect(elements[0].getAttribute('data-priority')).toBe('high')
+
+      expect(elements[1].getAttribute('data-computed')).toBe('odd')
+      expect(elements[1].getAttribute('aria-selected')).toBe('true')
+      expect(elements[1].getAttribute('data-priority')).toBe('medium')
+
+      expect(elements[2].getAttribute('data-computed')).toBe('even')
+      expect(elements[2].getAttribute('aria-selected')).toBe('false')
+      expect(elements[2].getAttribute('data-priority')).toBe('low')
+    })
+
+    it('should handle functions returning null to remove attributes', () => {
+      elements.forEach(el => {
+        el.setAttribute('data-conditional', 'initial')
+      })
+
+      useAttributes(elements, {
+        'data-conditional': (el) => {
+          const index = parseInt(el.dataset.index)
+          return index === 1 ? null : `value-${index}`
+        }
+      })
+
+      expect(elements[0].getAttribute('data-conditional')).toBe('value-0')
+      expect(elements[1].hasAttribute('data-conditional')).toBe(false)
+      expect(elements[2].getAttribute('data-conditional')).toBe('value-2')
+    })
+  })
 }) 

--- a/src/tests/useClasses.spec.js
+++ b/src/tests/useClasses.spec.js
@@ -6,23 +6,23 @@ import * as hookContext from '../core/hookContext.js'
 
 describe('useClasses', () => {
   let element
-  
+
   beforeEach(() => {
     // Create a fresh element for each test
     element = document.createElement('div')
     document.body.appendChild(element)
-    
+
     // Ensure the element has no classes
     element.className = ''
-    
+
     // Use fake timers for effect scheduling
     vi.useFakeTimers()
   })
-  
+
   afterEach(() => {
     vi.useRealTimers()
   })
-  
+
   it('should add classes when their conditions are true', () => {
     // Apply classes
     useClasses(element, {
@@ -30,77 +30,95 @@ describe('useClasses', () => {
       hidden: false,
       selected: true
     })
-    
+
     // Verify classes were added correctly
     expect(element.classList.contains('active')).toBe(true)
     expect(element.classList.contains('hidden')).toBe(false)
     expect(element.classList.contains('selected')).toBe(true)
   })
-  
+
   it('should return a cleanup function that removes added classes', () => {
     // Apply classes and get cleanup function
     const cleanup = useClasses(element, {
       active: true,
       selected: true
     })
-    
+
     // Verify classes were initially added
     expect(element.classList.contains('active')).toBe(true)
     expect(element.classList.contains('selected')).toBe(true)
-    
+
     // Call cleanup function
     cleanup()
-    
+
     // Verify classes were removed
     expect(element.classList.contains('active')).toBe(false)
     expect(element.classList.contains('selected')).toBe(false)
   })
-  
+
   it('should only track and remove classes that were actually added', () => {
     // Setup - add some classes directly
     element.classList.add('preexisting')
-    
+
     // Mock the classList.remove method to check which classes are removed
     const removeSpy = vi.spyOn(element.classList, 'remove')
-    
+
     // Apply classes with some false conditions
     const cleanup = useClasses(element, {
       active: true,
       hidden: false,  // This won't be added or tracked
       selected: true
     })
-    
+
     // Call cleanup
     cleanup()
-    
+
     // Verify only the classes that were added are removed
     expect(removeSpy).toHaveBeenCalledWith('active')
     expect(removeSpy).toHaveBeenCalledWith('selected')
     expect(removeSpy).not.toHaveBeenCalledWith('hidden')
-    
+
     // The preexisting class should not be removed
     expect(element.classList.contains('preexisting')).toBe(true)
   })
-  
+
+  it('should gracefully handle null/undefined elements with warning', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => { })
+
+    const cleanupNull = useClasses(null, { 'active': true })
+
+    const cleanupUndefined = useClasses(undefined, { 'active': true })
+
+    expect(consoleSpy).toHaveBeenCalledTimes(2)
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('useClasses called with null/undefined element'))
+
+    expect(typeof cleanupNull).toBe('function')
+    expect(typeof cleanupUndefined).toBe('function')
+
+    expect(() => cleanupNull()).not.toThrow()
+    expect(() => cleanupUndefined()).not.toThrow()
+
+    consoleSpy.mockRestore()
+  })
+
   it('should throw an error if called with a non-HTMLElement', () => {
-    expect(() => Function.prototype.apply.call(useClasses, null, [null, {}])).toThrow()
     expect(() => Function.prototype.apply.call(useClasses, null, [{}, {}])).toThrow()
   })
-  
+
   it('should throw an error if classMap is not a non-empty object', () => {
     expect(() => useClasses(element, null)).toThrow()
     expect(() => useClasses(element, {})).toThrow()
     expect(() => useClasses(element, 'string')).toThrow()
   })
-  
+
   it('should reactively update classes when signal values change', () => {
     // Spy on the effect execution to see what's happening
     const executeEffectSpy = vi.spyOn(hookContext, 'useEffect')
-    
+
     // Create signals for class conditions
     const isActive = signal(true)
     const isHidden = signal(false)
-    
+
     // We need to use withHookContext for useEffect to work
     withHookContext(element, () => {
       // Apply classes using signals
@@ -109,36 +127,36 @@ describe('useClasses', () => {
         hidden: isHidden,
         static: true // Regular boolean
       })
-      
+
       // Verify initial state
       expect(element.classList.contains('active')).toBe(true)
       expect(element.classList.contains('hidden')).toBe(false)
       expect(element.classList.contains('static')).toBe(true)
-      
+
       // Need to manually change signal values and manually trigger signal subscriptions
       // by running the effect callback rather than relying on timers
       isActive.value = false
       isHidden.value = true
-      
+
       // Extract and call the effect callback from the second call to useEffect (which should be our subscription)
       const effectCall = executeEffectSpy.mock.calls[0]
       const effectFn = effectCall[0]
       effectFn()
-      
+
       // Verify classes were updated correctly
       expect(element.classList.contains('active')).toBe(false)
       expect(element.classList.contains('hidden')).toBe(true)
       expect(element.classList.contains('static')).toBe(true) // Unchanged
     })
   })
-  
+
   it('should handle a mix of signal and boolean conditions', () => {
     // Spy on the effect execution 
     const executeEffectSpy = vi.spyOn(hookContext, 'useEffect')
-    
+
     // Create a signal for one class
     const isActive = signal(false)
-    
+
     withHookContext(element, () => {
       // Apply classes with mix of signal and direct boolean
       useClasses(element, {
@@ -146,20 +164,20 @@ describe('useClasses', () => {
         selected: true,    // Direct boolean
         highlighted: false // Direct boolean
       })
-      
+
       // Verify initial state
       expect(element.classList.contains('active')).toBe(false)
       expect(element.classList.contains('selected')).toBe(true)
       expect(element.classList.contains('highlighted')).toBe(false)
-      
+
       // Change signal value
       isActive.value = true
-      
+
       // Extract and call the effect callback
       const effectCall = executeEffectSpy.mock.calls[0]
       const effectFn = effectCall[0]
       effectFn()
-      
+
       // Verify only the signal-bound class changed
       expect(element.classList.contains('active')).toBe(true)
       expect(element.classList.contains('selected')).toBe(true)

--- a/src/tests/useEvents.spec.js
+++ b/src/tests/useEvents.spec.js
@@ -6,182 +6,242 @@ import * as hookContext from '../core/hookContext.js'
 
 describe('useEvents', () => {
   let element
-  
+
   beforeEach(() => {
     // Create a fresh element for each test
     element = document.createElement('div')
     document.body.appendChild(element)
     vi.useFakeTimers()
   })
-  
+
   afterEach(() => {
     vi.useRealTimers()
   })
-  
+
   it('should attach event listeners to the element', () => {
     // Setup
     const clickHandler = vi.fn()
     const mouseoverHandler = vi.fn()
-    
+
     // Spy on addEventListener
     const addEventSpy = vi.spyOn(element, 'addEventListener')
-    
+
     // Apply event listeners via useEvents
     useEvents(element, {
       click: clickHandler,
       mouseover: mouseoverHandler
     })
-    
+
     // Verify event listeners were attached
     expect(addEventSpy).toHaveBeenCalledTimes(2)
     expect(addEventSpy).toHaveBeenCalledWith('click', clickHandler)
     expect(addEventSpy).toHaveBeenCalledWith('mouseover', mouseoverHandler)
   })
-  
+
   it('should return a cleanup function that removes event listeners', () => {
     // Setup
     const clickHandler = vi.fn()
     const mouseoverHandler = vi.fn()
-    
+
     // Spy on removeEventListener
     const removeEventSpy = vi.spyOn(element, 'removeEventListener')
-    
+
     // Apply event listeners and get cleanup function
     const cleanup = useEvents(element, {
       click: clickHandler,
       mouseover: mouseoverHandler
     })
-    
+
     // Call cleanup function
     cleanup()
-    
+
     // Verify event listeners were removed
     expect(removeEventSpy).toHaveBeenCalledTimes(2)
     expect(removeEventSpy).toHaveBeenCalledWith('click', clickHandler)
     expect(removeEventSpy).toHaveBeenCalledWith('mouseover', mouseoverHandler)
   })
-  
+
   it('should skip non-function handlers with a warning', () => {
     // Setup
-    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => { })
     const addEventSpy = vi.spyOn(element, 'addEventListener')
-    
+
     // Apply event listeners with a non-function handler
     useEvents(element, {
-      click: () => {},  // Valid
+      click: () => { },  // Valid
       mouseover: 'not a function'  // Invalid
     })
-    
+
     // Verify only the valid handler was attached
     expect(addEventSpy).toHaveBeenCalledTimes(1)
     expect(addEventSpy).toHaveBeenCalledWith('click', expect.any(Function))
-    
+
     // Verify warning was logged
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('mouseover'))
   })
-  
-  it('should throw an error if called with a non-HTMLElement', () => {
-    expect(() => Function.prototype.apply.call(useEvents, null, [null, {}])).toThrow()
-    expect(() => Function.prototype.apply.call(useEvents, null, [{}, {}])).toThrow()
+
+  it('should gracefully handle null/undefined elements with warning', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => { })
+
+    const cleanupNull = useEvents(null, { click: vi.fn() })
+
+    const cleanupUndefined = useEvents(undefined, { click: vi.fn() })
+
+    expect(consoleSpy).toHaveBeenCalledTimes(2)
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('useEvents called with null/undefined element'))
+
+    expect(typeof cleanupNull).toBe('function')
+    expect(typeof cleanupUndefined).toBe('function')
+
+    expect(() => cleanupNull()).not.toThrow()
+    expect(() => cleanupUndefined()).not.toThrow()
+
+    consoleSpy.mockRestore()
   })
-  
+
+  it('should throw an error if called with invalid non-EventTarget elements', () => {
+    expect(() => useEvents({}, {})).toThrow()
+    expect(() => useEvents('string', {})).toThrow()
+    expect(() => useEvents(123, {})).toThrow()
+  })
+
+  it('should work with document and window objects', () => {
+    // Setup handlers
+    const documentHandler = vi.fn()
+    const windowHandler = vi.fn()
+
+    // Setup spies
+    const documentAddSpy = vi.spyOn(document, 'addEventListener')
+    const windowAddSpy = vi.spyOn(window, 'addEventListener')
+    const documentRemoveSpy = vi.spyOn(document, 'removeEventListener')
+    const windowRemoveSpy = vi.spyOn(window, 'removeEventListener')
+
+    // Test with document
+    const documentCleanup = useEvents(document, {
+      click: documentHandler
+    })
+
+    // Test with window
+    const windowCleanup = useEvents(window, {
+      resize: windowHandler
+    })
+
+    // Verify event listeners were attached
+    expect(documentAddSpy).toHaveBeenCalledWith('click', documentHandler)
+    expect(windowAddSpy).toHaveBeenCalledWith('resize', windowHandler)
+
+    // Test cleanup functions
+    documentCleanup()
+    windowCleanup()
+
+    // Verify event listeners were removed
+    expect(documentRemoveSpy).toHaveBeenCalledWith('click', documentHandler)
+    expect(windowRemoveSpy).toHaveBeenCalledWith('resize', windowHandler)
+
+    // Restore spies
+    documentAddSpy.mockRestore()
+    windowAddSpy.mockRestore()
+    documentRemoveSpy.mockRestore()
+    windowRemoveSpy.mockRestore()
+  })
+
   it('should throw an error if eventMap is not a non-empty object', () => {
     expect(() => useEvents(element, null)).toThrow()
     expect(() => useEvents(element, {})).toThrow()
     expect(() => useEvents(element, 'string')).toThrow()
   })
-  
+
   it('should reactively update event handlers when signal values change', () => {
     // Spy on the effect execution
     const executeEffectSpy = vi.spyOn(hookContext, 'useEffect')
-    
+
     // Create handlers
     const handler1 = vi.fn()
     const handler2 = vi.fn()
-    
+
     // Create a signal with the first handler
     const clickHandlerSignal = signal(handler1)
-    
+
     // Setup spies
     const addEventSpy = vi.spyOn(element, 'addEventListener')
     const removeEventSpy = vi.spyOn(element, 'removeEventListener')
-    
+
     withHookContext(element, () => {
       // Apply events using signal
       useEvents(element, {
         click: clickHandlerSignal
       })
-      
+
       // Verify initial handler was attached
       expect(addEventSpy).toHaveBeenCalledWith('click', handler1)
-      
+
       // Trigger the event and verify handler1 is called
       element.click()
       expect(handler1).toHaveBeenCalledTimes(1)
       expect(handler2).toHaveBeenCalledTimes(0)
-      
+
       // Reset spies for cleaner assertions
       addEventSpy.mockClear()
       removeEventSpy.mockClear()
-      
+
       // Change the handler in the signal
       clickHandlerSignal.value = handler2
-      
+
       // Extract and call the effect callback
       const effectCall = executeEffectSpy.mock.calls[0]
       const effectFn = effectCall[0]
       effectFn()
-      
+
       // Verify old handler was removed and new one was added
       expect(removeEventSpy).toHaveBeenCalledWith('click', handler1)
       expect(addEventSpy).toHaveBeenCalledWith('click', handler2)
-      
+
       // Trigger event again and verify handler2 is now called
       element.click()
       expect(handler1).toHaveBeenCalledTimes(1) // Still just once
       expect(handler2).toHaveBeenCalledTimes(1) // Now called
     })
   })
-  
+
   it('should handle a mix of signal and direct event handlers', () => {
     // Spy on the effect execution
     const executeEffectSpy = vi.spyOn(hookContext, 'useEffect')
-    
+
     // Create handlers
     const clickHandler = vi.fn()
     const mouseoverHandler = vi.fn()
     const newMouseoverHandler = vi.fn()
-    
+
     // Create a signal for mouseover
     const mouseoverSignal = signal(mouseoverHandler)
-    
+
     withHookContext(element, () => {
       // Apply events with a mix of direct and signal handlers
       useEvents(element, {
         click: clickHandler,         // Direct function
         mouseover: mouseoverSignal   // Signal
       })
-      
+
       // Simulate events and verify initial handlers
       element.click()
       element.dispatchEvent(new MouseEvent('mouseover'))
-      
+
       expect(clickHandler).toHaveBeenCalledTimes(1)
       expect(mouseoverHandler).toHaveBeenCalledTimes(1)
       expect(newMouseoverHandler).toHaveBeenCalledTimes(0)
-      
+
       // Change only the signal handler
       mouseoverSignal.value = newMouseoverHandler
-      
+
       // Extract and call the effect callback
       const effectCall = executeEffectSpy.mock.calls[0]
       const effectFn = effectCall[0]
       effectFn()
-      
+
       // Simulate events again
       element.click()
       element.dispatchEvent(new MouseEvent('mouseover'))
-      
+
       // Verify click handler still works, and mouseover changed
       expect(clickHandler).toHaveBeenCalledTimes(2)       // Incremented
       expect(mouseoverHandler).toHaveBeenCalledTimes(1)   // Unchanged

--- a/src/tests/useEvents.spec.js
+++ b/src/tests/useEvents.spec.js
@@ -145,6 +145,39 @@ describe('useEvents', () => {
     windowRemoveSpy.mockRestore()
   })
 
+  it('should work with arrays of elements', () => {
+    const button1 = document.createElement('button')
+    const button2 = document.createElement('button')
+    const button3 = document.createElement('button')
+    const buttons = [button1, button2, button3]
+
+    const clickHandler = vi.fn()
+    const mouseoverHandler = vi.fn()
+
+    const addEventSpies = buttons.map(btn => vi.spyOn(btn, 'addEventListener'))
+    const removeEventSpies = buttons.map(btn => vi.spyOn(btn, 'removeEventListener'))
+
+    const cleanup = useEvents(buttons, {
+      click: clickHandler,
+      mouseover: mouseoverHandler
+    })
+
+    buttons.forEach((btn, index) => {
+      expect(addEventSpies[index]).toHaveBeenCalledWith('click', clickHandler)
+      expect(addEventSpies[index]).toHaveBeenCalledWith('mouseover', mouseoverHandler)
+    })
+
+    cleanup()
+
+    buttons.forEach((btn, index) => {
+      expect(removeEventSpies[index]).toHaveBeenCalledWith('click', clickHandler)
+      expect(removeEventSpies[index]).toHaveBeenCalledWith('mouseover', mouseoverHandler)
+    })
+
+    addEventSpies.forEach(spy => spy.mockRestore())
+    removeEventSpies.forEach(spy => spy.mockRestore())
+  })
+
   it('should throw an error if eventMap is not a non-empty object', () => {
     expect(() => useEvents(element, null)).toThrow()
     expect(() => useEvents(element, {})).toThrow()

--- a/src/tests/useStyles.spec.js
+++ b/src/tests/useStyles.spec.js
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useStyles } from '../hooks/useStyles.js'
 
 describe('useStyles', () => {
@@ -57,8 +57,26 @@ describe('useStyles', () => {
     expect(element.style.padding).toBe('')
   })
 
+  it('should gracefully handle null/undefined elements with warning', () => {
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => { })
+
+    const cleanupNull = useStyles(null, { color: 'red' })
+
+    const cleanupUndefined = useStyles(undefined, { color: 'red' })
+
+    expect(consoleSpy).toHaveBeenCalledTimes(2)
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('useStyles called with null/undefined element'))
+
+    expect(typeof cleanupNull).toBe('function')
+    expect(typeof cleanupUndefined).toBe('function')
+
+    expect(() => cleanupNull()).not.toThrow()
+    expect(() => cleanupUndefined()).not.toThrow()
+
+    consoleSpy.mockRestore()
+  })
+
   it('should throw an error if first argument is not an HTMLElement', () => {
-    expect(() => useStyles(null, {})).toThrow()
     expect(() => useStyles({}, {})).toThrow()
     expect(() => useStyles('div', {})).toThrow()
   })

--- a/src/tests/useStyles.spec.js
+++ b/src/tests/useStyles.spec.js
@@ -77,14 +77,183 @@ describe('useStyles', () => {
   })
 
   it('should throw an error if first argument is not an HTMLElement', () => {
+    // @ts-expect-error
     expect(() => useStyles({}, {})).toThrow()
+    // @ts-expect-error
     expect(() => useStyles('div', {})).toThrow()
   })
 
   it('should throw an error if second argument is not a non-empty object', () => {
+    // @ts-expect-error
     expect(() => useStyles(element, null)).toThrow()
     expect(() => useStyles(element, 'string')).toThrow()
+    // @ts-expect-error
     expect(() => useStyles(element, [])).toThrow()
     expect(() => useStyles(element, {})).toThrow()
+  })
+
+  describe('Array Support', () => {
+    let elements
+
+    beforeEach(() => {
+      elements = [
+        document.createElement('div'),
+        document.createElement('div'),
+        document.createElement('div')
+      ]
+
+      elements.forEach((el, index) => {
+        el.setAttribute('data-id', index.toString())
+        el.setAttribute('data-color', ['red', 'green', 'blue'][index])
+        el.setAttribute('data-width', `${(index + 1) * 100}px`)
+      })
+    })
+
+    it('should handle array of elements with function conditions', () => {
+      useStyles(elements, {
+        backgroundColor: (el) => el.dataset.color,
+        width: (el) => el.dataset.width,
+        opacity: (el) => el.dataset.id === '1' ? '0.5' : '1'
+      })
+
+      expect(elements[0].style.backgroundColor).toBe('red')
+      expect(elements[0].style.width).toBe('100px')
+      expect(elements[0].style.opacity).toBe('1')
+
+      expect(elements[1].style.backgroundColor).toBe('green')
+      expect(elements[1].style.width).toBe('200px')
+      expect(elements[1].style.opacity).toBe('0.5')
+
+      expect(elements[2].style.backgroundColor).toBe('blue')
+      expect(elements[2].style.width).toBe('300px')
+      expect(elements[2].style.opacity).toBe('1')
+    })
+
+    it('should handle mixed function, signal, and direct value conditions', () => {
+      const globalColor = { value: 'purple', subscribe: () => { } }
+
+      useStyles(elements, {
+        backgroundColor: (el) => el.dataset.color,
+        borderColor: globalColor,
+        padding: '10px'
+      })
+
+      elements.forEach((el, index) => {
+        expect(el.style.backgroundColor).toBe(['red', 'green', 'blue'][index])
+        expect(el.style.borderColor).toBe('purple')
+        expect(el.style.padding).toBe('10px')
+      })
+    })
+
+    it('should handle kebab-case properties with arrays', () => {
+      useStyles(elements, {
+        'background-color': (el) => el.dataset.color,
+        'font-size': '16px'
+      })
+
+      elements.forEach((el, index) => {
+        expect(el.style.backgroundColor).toBe(['red', 'green', 'blue'][index])
+        expect(el.style.fontSize).toBe('16px')
+      })
+    })
+
+    it('should cleanup styles correctly for each element', () => {
+      elements.forEach(el => {
+        el.style.color = 'black'
+        el.style.margin = '5px'
+      })
+
+      const cleanup = useStyles(elements, {
+        backgroundColor: (el) => el.dataset.color,
+        color: 'white',
+        fontSize: '14px'
+      })
+
+      elements.forEach((el, index) => {
+        expect(el.style.backgroundColor).toBe(['red', 'green', 'blue'][index])
+        expect(el.style.color).toBe('white')
+        expect(el.style.fontSize).toBe('14px')
+      })
+
+      cleanup()
+
+      elements.forEach(el => {
+        expect(el.style.backgroundColor).toBe('')
+        expect(el.style.color).toBe('black') // Original preserved
+        expect(el.style.fontSize).toBe('')
+        expect(el.style.margin).toBe('5px') // Untouched style preserved
+      })
+    })
+
+    it('should handle single element passed as array', () => {
+      const singleElementArray = [elements[0]]
+
+      useStyles(singleElementArray, {
+        color: 'red',
+        fontSize: (el) => el.dataset.id === '0' ? '18px' : '12px'
+      })
+
+      expect(elements[0].style.color).toBe('red')
+      expect(elements[0].style.fontSize).toBe('18px')
+      expect(elements[1].style.color).toBe('')
+      expect(elements[2].style.color).toBe('')
+    })
+
+    it('should maintain backward compatibility with single elements', () => {
+      useStyles(elements[0], {
+        color: 'red',
+        fontSize: '16px'
+      })
+
+      expect(elements[0].style.color).toBe('red')
+      expect(elements[0].style.fontSize).toBe('16px')
+      expect(elements[1].style.color).toBe('')
+      expect(elements[2].style.color).toBe('')
+    })
+
+    it('should handle null/undefined in array gracefully', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => { })
+
+      const cleanupNull = useStyles(null, { color: 'red' })
+
+      const cleanupUndefined = useStyles(undefined, { color: 'red' })
+
+      expect(consoleSpy).toHaveBeenCalledTimes(2)
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('useStyles called with null/undefined element'))
+
+      expect(typeof cleanupNull).toBe('function')
+      expect(typeof cleanupUndefined).toBe('function')
+
+      expect(() => cleanupNull()).not.toThrow()
+      expect(() => cleanupUndefined()).not.toThrow()
+
+      consoleSpy.mockRestore()
+    })
+
+    it('should throw error for invalid elements in array', () => {
+      const invalidArray = [elements[0], 'not-an-element', elements[1]]
+
+      expect(() => useStyles(invalidArray, { color: 'red' })).toThrow('[HookTML] useStyles requires HTMLElement(s) as first argument')
+    })
+
+    it('should handle complex function conditions with calculations', () => {
+      useStyles(elements, {
+        width: (el) => `${parseInt(el.dataset.id) * 50 + 100}px`,
+        height: (el) => el.dataset.id === '1' ? '200px' : '100px',
+        transform: (el) => `translateX(${parseInt(el.dataset.id) * 10}px)`
+      })
+
+      expect(elements[0].style.width).toBe('100px')
+      expect(elements[0].style.height).toBe('100px')
+      expect(elements[0].style.transform).toBe('translateX(0px)')
+
+      expect(elements[1].style.width).toBe('150px')
+      expect(elements[1].style.height).toBe('200px')
+      expect(elements[1].style.transform).toBe('translateX(10px)')
+
+      expect(elements[2].style.width).toBe('200px')
+      expect(elements[2].style.height).toBe('100px')
+      expect(elements[2].style.transform).toBe('translateX(20px)')
+    })
   })
 }) 

--- a/src/utils/type-guards.js
+++ b/src/utils/type-guards.js
@@ -133,6 +133,13 @@ export const isEventTarget = value => {
 }
 
 /**
+ * Check if a value is an array of valid event targets
+ * @param {unknown} value
+ * @returns {value is EventTarget[]} Whether or not the value is an array of valid event targets
+ */
+export const isEventTargetArray = value => isNonEmptyArray(value) && value.every(isEventTarget)
+
+/**
  * Check if a value is an object
  * @param {unknown} value
  * @returns {value is Record<string, unknown>} Whether or not the value is an object

--- a/src/utils/type-guards.js
+++ b/src/utils/type-guards.js
@@ -140,6 +140,13 @@ export const isEventTarget = value => {
 export const isEventTargetArray = value => isNonEmptyArray(value) && value.every(isEventTarget)
 
 /**
+ * Check if a value is an array of HTMLElements
+ * @param {unknown} value
+ * @returns {value is HTMLElement[]} Whether or not the value is an array of HTMLElements
+ */
+export const isHTMLElementArray = value => isNonEmptyArray(value) && value.every(isHTMLElement)
+
+/**
  * Check if a value is an object
  * @param {unknown} value
  * @returns {value is Record<string, unknown>} Whether or not the value is an object

--- a/src/utils/type-guards.js
+++ b/src/utils/type-guards.js
@@ -4,7 +4,7 @@
  * @param {unknown} value - The value to check.
  * @returns {value is null | undefined} Whether or not the value is null or undefined.
  */
-export const isNil = value => 
+export const isNil = value =>
   value === null || typeof value === 'undefined'
 
 /**
@@ -108,6 +108,16 @@ export const isNonEmptyArray = value => isArray(value) && value.length > 0
  * @returns {value is HTMLElement} Whether or not the value is an HTMLElement
  */
 export const isHTMLElement = value => value instanceof HTMLElement
+
+/**
+ * Check if a value is a valid event target (HTMLElement, Document, or Window)
+ * @param {unknown} value
+ * @returns {value is EventTarget} Whether or not the value is a valid event target
+ */
+export const isEventTarget = value =>
+  value instanceof HTMLElement ||
+  value instanceof Document ||
+  value instanceof Window
 
 /**
  * Check if a value is an object

--- a/src/utils/type-guards.js
+++ b/src/utils/type-guards.js
@@ -114,10 +114,23 @@ export const isHTMLElement = value => value instanceof HTMLElement
  * @param {unknown} value
  * @returns {value is EventTarget} Whether or not the value is a valid event target
  */
-export const isEventTarget = value =>
-  value instanceof HTMLElement ||
-  value instanceof Document ||
-  value instanceof Window
+export const isEventTarget = value => {
+  if (!value || typeof value !== 'object') return false
+
+  if (value instanceof HTMLElement) return true
+
+  if (value === document ||
+    ('nodeType' in value && value.nodeType === 9 && 'addEventListener' in value && isFunction(value.addEventListener))) {
+    return true
+  }
+
+  if (value === window ||
+    ('window' in value && value.window === value && 'addEventListener' in value && isFunction(value.addEventListener))) {
+    return true
+  }
+
+  return false
+}
 
 /**
  * Check if a value is an object


### PR DESCRIPTION
### Description

All utility hooks (useEvents, useClasses, useStyles, useAttributes) now accept an optional deps array for explicit reactivity, and per-element functions receive both the element and its index. The “Array Support” section shows signal-free use cases that work automatically, while a new “Manual Dependencies” section highlights when to pass deps for signal-based logic. Code samples were streamlined (e.g., useEvents(tabButtons, …)), the API table now lists the deps? parameter, and direct-signal examples illustrate implicit tracking (disabled: isGloballyDisabled).

The PR also adds codepen example links to show how some features might be built in the real world.