### PR TITLE
fix: Add missing multi-prop implementation for hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2025-01-27
+
+### Fixed
+
+- **Multiple Hook Props**: Implemented missing functionality for passing multiple props to hooks
+  - Hooks now correctly receive additional props beyond the main `use-*` attribute value
+  - Example: `<button use-tooltip="text" tooltip-placement="top" tooltip-color="blue">` now works as documented
+  - Added `extractHookProps` function that reuses existing prop extraction logic for DRY implementation
+  - Fixed broken examples like `counter-initial="0"` in simple-counter.html
+  - Maintains backward compatibility - existing hooks continue to work unchanged
+
+### Technical
+
+- Reused existing `extractProps` infrastructure to keep codebase DRY and consistent
+- Added comprehensive test coverage with 6 new unit tests and 1 integration test
+- All 316 tests continue to pass
+
 ## [0.5.0] - 2025-01-27
 
 ### Added
+
 - **`useText` Hook**: New utility hook for declarative text content updates
   - `useText(element, textFunction, deps?)` - Set text content reactively with dependencies
   - Function receives element and returns text to display
@@ -16,12 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Comprehensive validation with graceful error handling
 
 ### Enhanced
+
 - **Documentation**: Updated README with `useText` examples throughout
   - Replaced manual `textContent` assignments with cleaner `useText` calls
   - Added to API reference and declarative content hooks sections
   - Updated Quick Example and Advanced Patterns sections
 
 ### Technical
+
 - Added comprehensive test suite with 17 passing tests
 - Exported from main package and utility hooks index
 - Follows existing hook patterns for consistency
@@ -29,7 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.2] - 2025-01-27
 
 ### Fixed
+
 - **Auto-registration**: Fixed bundler auto-registration to properly handle componentPath limitations
+
   - Bundler environments now gracefully handle static analysis requirements
   - Node.js filesystem auto-registration continues to work with any componentPath
   - Improved debug messaging for environment-specific behavior
@@ -42,9 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.0] - 2025-07-24
 
 ### Added
+
 - **Array Support for All Hooks**: All utility hooks now support arrays of elements with per-element logic
   - `useClasses(elements, { className: (el, index) => condition })` - Apply classes with element-specific functions
-  - `useStyles(elements, { property: (el, index) => value })` - Apply styles with element-specific functions  
+  - `useStyles(elements, { property: (el, index) => value })` - Apply styles with element-specific functions
   - `useAttributes(elements, { attr: (el, index) => value })` - Set attributes with element-specific functions
   - `useEvents(elements, { event: (event, index) => handler })` - Event handlers receive both event and element index
 - **Manual Dependencies**: All utility hooks now accept optional deps array for explicit reactivity control
@@ -54,11 +77,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `useEvents(elements, eventMap, [signal])` - Control when event handlers update based on signals
 
 ### Enhanced
+
 - **Graceful Nil Handling**: All hooks now handle `null`/`undefined` elements gracefully with warnings instead of throwing errors
 - **Memory Optimization**: WeakMap-based per-element tracking for automatic garbage collection
 - **API Consistency**: All hooks follow the same patterns for array support and mixed condition types
 
 ### Technical
+
 - Added `isHTMLElementArray` type guard for consistent array validation
 - Enhanced test coverage with 290 total passing tests
 - Improved documentation with array support examples
@@ -66,16 +91,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - 2025-07-08
 
 ### Added
+
 - **Browser Script Tag Support**: HookTML can now be imported via `<script>` tag for direct HTML usage
   - Global build available at `index.global.js` - exposes `HookTML` global object
   - Browser build available at `index.browser.js` - optimized for browser environments
   - CDN-ready distribution for quick prototyping and development
 
 ### Enhanced
+
 - **Multiple Export Formats**: Package now supports Node.js, browser, and global script environments
 - **Improved Package Structure**: Clear separation between different build targets
 
 ### Technical
+
 - Added `index.global.js` and `index.browser.js` build outputs
 - Updated package.json exports for better module resolution
-- Enhanced build pipeline for multiple distribution formats 
+- Enhanced build pipeline for multiple distribution formats

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooktml",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A reactive HTML component library with hooks-based lifecycle management",
   "main": "index.js",
   "type": "module",

--- a/src/core/scanDirectives.js
+++ b/src/core/scanDirectives.js
@@ -2,7 +2,7 @@ import { getRegisteredHooks, getRegisteredHook } from './hookRegistry.js'
 import { camelToKebab, kebabToCamel } from '../utils/strings.js'
 import { isHTMLElement, isNotNil, isNonEmptyString, isEmptyString, isFunction, isEmptyArray } from '../utils/type-guards.js'
 import { tryCatch } from '../utils/try-catch.js'
-import { coerceValue } from '../utils/props.js'
+import { coerceValue, extractHookProps } from '../utils/props.js'
 import { lifecycleManager } from './initialization.js'
 import { withHookContext } from './hookContext.js'
 import { logger } from '../utils/logger.js'
@@ -17,10 +17,10 @@ import { getHookInstance, storeHookInstance } from './hookInstanceRegistry.js'
  */
 const createHookSelector = (hookNames, prefix = '') => {
   if (!hookNames.length) return ''
-  
+
   // Convert camelCase hook names to kebab-case attributes with prefix
   const attributeNames = hookNames.map(name => `[${prefix}${camelToKebab(name)}]`)
-  
+
   // Join with commas to create a single selector
   return attributeNames.join(', ')
 }
@@ -34,7 +34,7 @@ const createHookSelector = (hookNames, prefix = '') => {
 const getHookAttributesFromElement = (element, prefix = '') => {
   const attributes = Array.from(element.attributes)
   const usePrefix = `${prefix}use-`
-  
+
   return attributes
     .filter(attr => attr.name.startsWith(usePrefix))
     .map(attr => ({
@@ -51,59 +51,51 @@ const getHookAttributesFromElement = (element, prefix = '') => {
 export const processElementHooks = (element) => {
   // Skip if already processed - prevents infinite loop
   const hasTeardowns = lifecycleManager.hasRegistration(element)
-  
+
   if (hasTeardowns) {
     logger.log('⏭️ Skipping already processed element', element)
     return
   }
-  
+
   const { formattedPrefix } = getConfig()
   const hookAttributes = getHookAttributesFromElement(element, formattedPrefix)
-  
+
   logger.log(`Processing element with ${hookAttributes.length} hook(s):`, element)
-  
+
   // For each hook attribute, find and call the corresponding function
-  hookAttributes.forEach(({ name, originalName, value }) => {    
+  hookAttributes.forEach(({ name, originalName, value }) => {
     // Properly capitalize the hook name (e.g., "teardown" -> "useTeardown")
     // Must use exact case to match registered hook
     const hookName = kebabToCamel(name)
-    
+
     logger.log(`Looking for hook "${hookName}" from attribute "${originalName}"`)
-    
+
     const hookFn = getRegisteredHook(hookName)
-    
+
     if (isNotNil(hookFn) && isFunction(hookFn)) {
       logger.log(`Found hook "${hookName}" for element:`, element)
-      
+
       // Check if we already have an instance for this hook
       const existingInstance = getHookInstance(element, hookName)
       if (existingInstance) {
         logger.log(`Using existing instance for hook "${hookName}"`)
         return // Skip re-initialization
       }
-      
-      // Coerce the attribute value to appropriate primitives
-      const parsedValue = isEmptyString(value) ? true : coerceValue(value)
-      
+
+      // Extract all props for this hook (including main value and additional props)
+      const props = extractHookProps(element, hookName, value)
+
       if (isNotNil(value)) {
-        logger.log(`Passing value to hook "${hookName}":`, parsedValue)
+        logger.log(`Passing props to hook "${hookName}":`, props)
       }
-      
-      // Create props object
-      const props = {}
-      
-      // Attribute values that are left empty in the DOM return 
-      if (isNonEmptyString(value)) {
-        props.value = parsedValue
-      }
-      
+
       // Call the hook and store any teardown function it returns
       const resultRef = { current: undefined }
-      
+
       tryCatch({
         fn: () => {
           logger.log(`Calling hook function for "${hookName}" with hook context`)
-          
+
           // Execute the hook function within a hook context to support useEffect
           resultRef.current = withHookContext(element, () => {
             const instance = hookFn(element, props)
@@ -111,20 +103,20 @@ export const processElementHooks = (element) => {
             storeHookInstance(element, hookName, instance)
             return instance
           })
-          
+
           logger.log(`Hook "${hookName}" returned:`, resultRef.current, typeof resultRef.current)
         },
         onError: (error) => {
           logger.error(`Error applying hook "${hookName}":`, error)
         }
       })
-      
+
       // If the hook returned a function, store it as a teardown function
       if (isFunction(resultRef.current)) {
         logger.log(`Storing teardown function for hook "${hookName}" on element:`, element)
-        
+
         lifecycleManager.registerDirective(element, resultRef.current, hookName)
-        
+
         // Verify teardown was stored
         const verifyTeardowns = lifecycleManager.hasRegistration(element)
         logger.log(`✅ Verified teardown is registered: ${verifyTeardowns}`)
@@ -145,26 +137,26 @@ export const scanDirectives = () => {
   const hooks = getRegisteredHooks()
   const hookNames = Array.from(hooks.keys())
   const { formattedPrefix } = getConfig()
-  
+
   if (isEmptyArray(hookNames)) {
     logger.log('No hooks registered yet')
     return 0
   }
-  
+
   // Create a combined selector for all hooks
   const selector = createHookSelector(hookNames, formattedPrefix)
-  
+
   logger.log(`Scanning DOM for hook directives with selector: "${selector}"`)
-  
+
   // Find all elements with use-* attributes and ensure they are HTMLElements
   /** @type {HTMLElement[]} */
   const elements = Array.from(document.querySelectorAll(selector))
     .filter(isHTMLElement)
-  
+
   logger.log(`Found ${elements.length} element(s) with hook directives`)
-  
+
   // Process each element by applying registered hooks
   elements.forEach(element => processElementHooks(element))
-  
+
   return elements.length
 } 

--- a/src/tests/props.spec.js
+++ b/src/tests/props.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import { extractProps } from '../utils/props.js'
+import { extractProps, extractHookProps } from '../utils/props.js'
 
 test('should extract and coerce props correctly', () => {
   // Setup
@@ -10,10 +10,10 @@ test('should extract and coerce props correctly', () => {
   element.setAttribute('tooltip-position', 'top')
   element.setAttribute('tooltip-null-value', 'null')
   element.setAttribute('tooltip-disabled', 'false')
-  
+
   // Execute
   const props = extractProps(element, 'Tooltip')
-  
+
   // Verify
   expect(props).toEqual({
     text: 'Hello World',
@@ -28,10 +28,10 @@ test('should extract and coerce props correctly', () => {
 test('should handle no props', () => {
   // Setup
   const element = document.createElement('div')
-  
+
   // Execute
   const props = extractProps(element, 'Tooltip')
-  
+
   // Verify
   expect(props).toEqual({})
 })
@@ -42,12 +42,91 @@ test('should ignore non-matching attributes', () => {
   element.setAttribute('data-test', 'test')
   element.setAttribute('class', 'tooltip')
   element.setAttribute('tooltip-text', 'Hello')
-  
+
   // Execute
   const props = extractProps(element, 'Tooltip')
-  
+
   // Verify
   expect(props).toEqual({
     text: 'Hello'
+  })
+})
+
+test('should extract hook props with main value and additional props', () => {
+  const element = document.createElement('button')
+  element.setAttribute('tooltip-placement', 'top')
+  element.setAttribute('tooltip-color', 'blue')
+  element.setAttribute('tooltip-delay', '1000')
+  element.setAttribute('tooltip-enabled', 'true')
+
+  const props = extractHookProps(element, 'useTooltip', 'Click to save')
+
+  expect(props).toEqual({
+    value: 'Click to save',
+    placement: 'top',
+    color: 'blue',
+    delay: 1000,
+    enabled: true
+  })
+})
+
+test('should extract hook props with only main value', () => {
+  const element = document.createElement('button')
+
+  const props = extractHookProps(element, 'useTooltip', 'Hello World')
+
+  expect(props).toEqual({
+    value: 'Hello World'
+  })
+})
+
+test('should extract hook props with only additional props', () => {
+  const element = document.createElement('div')
+  element.setAttribute('counter-initial', '42')
+  element.setAttribute('counter-step', '5')
+
+  const props = extractHookProps(element, 'useCounter', '')
+
+  expect(props).toEqual({
+    initial: 42,
+    step: 5
+  })
+})
+
+test('should handle hook props with no props', () => {
+  const element = document.createElement('div')
+
+  const props = extractHookProps(element, 'useFocus', '')
+
+  expect(props).toEqual({})
+})
+
+test('should ignore non-matching attributes for hooks', () => {
+  const element = document.createElement('button')
+  element.setAttribute('data-test', 'test')
+  element.setAttribute('class', 'button')
+  element.setAttribute('modal-id', 'test-modal') // Different hook prefix
+  element.setAttribute('tooltip-placement', 'top')
+
+  const props = extractHookProps(element, 'useTooltip', 'Click me')
+
+  expect(props).toEqual({
+    value: 'Click me',
+    placement: 'top'
+  })
+})
+
+test('should handle kebab-case to camelCase conversion for hook props', () => {
+  const element = document.createElement('div')
+  element.setAttribute('tooltip-max-width', '200')
+  element.setAttribute('tooltip-z-index', '1000')
+  element.setAttribute('tooltip-show-arrow', 'false')
+
+  const props = extractHookProps(element, 'useTooltip', '')
+
+  expect(props).toEqual({
+    maxWidth: 200,
+    zIndex: 1000,
+    showArrow: false
   })
 }) 


### PR DESCRIPTION
### Description

This pull request introduces a minor version update (0.5.1) focused on improving hook usability by allowing multiple props to be passed to hooks, fixing related issues, and increasing test coverage. The changes ensure that hooks can now receive additional props beyond the main attribute value, making the API more flexible and aligning behavior with documentation. The implementation is DRY, reusing existing prop extraction logic, and maintains backward compatibility.

### Hook Props Extraction Improvements
* Added `extractHookProps` function to `src/utils/props.js` to extract both the main value and additional props for hooks, reusing the existing `extractProps` infrastructure for consistency and maintainability.
* Updated `processElementHooks` in `src/core/scanDirectives.js` to use `extractHookProps`, ensuring hooks receive all relevant props from element attributes. [[1]](diffhunk://#diff-3859ab37d06d753af2a19f4fc49fcc6d72b74da8cb2169490a3cb7b42878377eL5-R5) [[2]](diffhunk://#diff-3859ab37d06d753af2a19f4fc49fcc6d72b74da8cb2169490a3cb7b42878377eL85-R89)

### Testing Enhancements
* Added 6 new unit tests and 1 integration test to validate multiple prop extraction for hooks, including edge cases and attribute conversion scenarios in `src/tests/props.spec.js` and `src/tests/hookDirectives.spec.js`. [[1]](diffhunk://#diff-a23380be00aa6874beb1189b41523dab7a0cc91133233d12515e7da93d0296d8L2-R2) [[2]](diffhunk://#diff-a23380be00aa6874beb1189b41523dab7a0cc91133233d12515e7da93d0296d8R54-R132) [[3]](diffhunk://#diff-029938e17e4ff5907f05d47522271d226317f1f5c80bfddedae9baf6f705848dR271-R321)

### Documentation & Changelog
* Updated `CHANGELOG.md` to document the new multiple props feature for hooks, example usage, technical details, and test coverage.

### Version Bump
* Bumped package version to `0.5.1` in `package.json` to reflect the new feature and fixes.