### PR TITLE
fix: Root Mutation Observation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.1] - 2025-01-27
+## [0.5.2] - 2025-09-14
+
+### Fixed
+
+- **DOM Observer Root**: Fixed DOM observer to attach to `document.documentElement` instead of `document.body`
+  - Resolves compatibility issues with libraries like Turbo that replace the body element on page navigation
+  - Ensures HookTML components and hooks remain active after body replacement operations
+  - Maintains full functionality during SPA-style page transitions
+
+## [0.5.1] - 2025-08-26
 
 ### Fixed
 
@@ -22,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added comprehensive test coverage with 6 new unit tests and 1 integration test
 - All 316 tests continue to pass
 
-## [0.5.0] - 2025-01-27
+## [0.5.0] - 2025-08-24
 
 ### Added
 
@@ -46,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exported from main package and utility hooks index
 - Follows existing hook patterns for consistency
 
-## [0.4.2] - 2025-01-27
+## [0.4.2] - 2025-08-05
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooktml",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A reactive HTML component library with hooks-based lifecycle management",
   "main": "index.js",
   "type": "module",

--- a/src/core/observer.js
+++ b/src/core/observer.js
@@ -49,7 +49,7 @@ const processMutation = (state, mutation) => {
         .filter(isHTMLElement)
       return [element, ...descendants]
     })
-    
+
   // Clean up removed elements
   removedElements.forEach(element => {
     if (state.elements.has(element)) {
@@ -193,22 +193,22 @@ const createHookTMLDelegate = () => {
     const hooks = getRegisteredHooks()
     const hookNames = Array.from(hooks.keys())
     const componentNames = getRegisteredComponentNames()
-    
+
     // Create selectors for hooks and components
     const selectors = []
-    
+
     if (isNonEmptyArray(hookNames)) {
       selectors.push(createHookSelector(hookNames, formattedPrefix))
     }
-    
+
     if (isNonEmptyArray(componentNames)) {
       selectors.push(createComponentSelector(componentNames, formattedPrefix))
     }
-    
+
     if (isEmptyArray(selectors)) {
       return []
     }
-    
+
     // Find all matching elements
     return Array.from(root.querySelectorAll(selectors.join(', ')))
       .filter(isHTMLElement)
@@ -225,14 +225,14 @@ const createHookTMLDelegate = () => {
         const { formattedPrefix } = getConfig()
         const hooks = getRegisteredHooks()
         const hookNames = Array.from(hooks.keys())
-        
+
         if (isNonEmptyArray(hookNames)) {
           const hookSelector = createHookSelector(hookNames, formattedPrefix)
           if (element.matches(hookSelector)) {
             processElementHooks(element)
           }
         }
-        
+
         // Process components
         const componentNames = getRegisteredComponentNames()
         if (isNonEmptyArray(componentNames)) {
@@ -274,24 +274,24 @@ const createHookTMLDelegate = () => {
 
   return { matchElements, addElement, removeElement }
 }
-  
+
 /**
  * Creates a DOM observer for HookTML
  * @returns {Object} Observer instance with start/stop methods
  */
 export const createObserver = () => {
   const delegate = createHookTMLDelegate()
-  const elementObserver = createElementObserver(document.body, delegate)
-  
+  const elementObserver = createElementObserver(document.documentElement, delegate)
+
   const start = () => {
     elementObserver.start()
     logger.log('DOM observation started')
   }
-  
+
   const stop = () => {
     elementObserver.stop()
     logger.log('DOM Observer stopped')
   }
-  
+
   return { start, stop }
 } 

--- a/src/tests/observer.spec.js
+++ b/src/tests/observer.spec.js
@@ -11,11 +11,11 @@ import * as registryModule from '../core/registry'
 describe('DOM Observer', () => {
   let observer
   let mockMutationObserver
-  
+
   beforeEach(() => {
     // Clear mocks first
     vi.clearAllMocks()
-    
+
     // Mock MutationObserver
     mockMutationObserver = {
       observe: vi.fn(),
@@ -26,35 +26,35 @@ describe('DOM Observer', () => {
       mockMutationObserver.callback = callback
       return mockMutationObserver
     })
-    
+
     // Create observer instance
     observer = createObserver()
   })
-  
+
   /**
    * Test starting observation
    */
   it('should start observing the DOM', () => {
     observer.start()
-    
+
     expect(MutationObserver).toHaveBeenCalled()
-    expect(mockMutationObserver.observe).toHaveBeenCalledWith(document.body, {
+    expect(mockMutationObserver.observe).toHaveBeenCalledWith(document.documentElement, {
       attributes: true,
       childList: true,
       subtree: true
     })
   })
-  
+
   /**
    * Test stopping observation
    */
   it('should stop observing the DOM', () => {
     observer.start()
     observer.stop()
-    
+
     expect(mockMutationObserver.disconnect).toHaveBeenCalled()
   })
-  
+
   /**
    * Test handling removed elements with teardown functions
    */
@@ -64,22 +64,22 @@ describe('DOM Observer', () => {
     const element2 = document.createElement('div')
     element1.setAttribute('use-test', 'true')
     element2.setAttribute('use-test', 'true')
-    
+
     // Mock hook registry to make elements trackable
     vi.spyOn(hookRegistryModule, 'getRegisteredHooks').mockReturnValue(new Map([['useTest', vi.fn()]]))
     vi.spyOn(registryModule, 'getRegisteredComponentNames').mockReturnValue([])
-    
+
     // Mock lifecycle functions
     const executeTeardownsSpy = vi.spyOn(initializationModule.lifecycleManager, 'executeTeardowns')
     const runCleanupFunctionsSpy = vi.spyOn(hookContextModule, 'runCleanupFunctions')
-    
+
     // Start observer and add elements to tracking
     observer.start()
-    
+
     // Simulate the elements being added first (so they get tracked)
     document.body.appendChild(element1)
     document.body.appendChild(element2)
-    
+
     // Trigger refresh to track the elements
     const addMutations = [{
       type: 'childList',
@@ -87,23 +87,23 @@ describe('DOM Observer', () => {
       removedNodes: []
     }]
     mockMutationObserver.callback(addMutations)
-    
+
     // Now simulate removal of elements
     const removeMutations = [{
       type: 'childList',
       addedNodes: [],
       removedNodes: [element1, element2]
     }]
-    
+
     mockMutationObserver.callback(removeMutations)
-    
+
     // Verify teardown was called for each element
     expect(executeTeardownsSpy).toHaveBeenCalledWith(element1)
     expect(executeTeardownsSpy).toHaveBeenCalledWith(element2)
     expect(runCleanupFunctionsSpy).toHaveBeenCalledWith(element1)
     expect(runCleanupFunctionsSpy).toHaveBeenCalledWith(element2)
   })
-  
+
   /**
    * Test handling nested elements
    */
@@ -114,17 +114,17 @@ describe('DOM Observer', () => {
     parent.appendChild(child)
     parent.setAttribute('use-test', 'true')
     child.setAttribute('use-test', 'true')
-    
+
     // Mock hook registry to make elements trackable
     vi.spyOn(hookRegistryModule, 'getRegisteredHooks').mockReturnValue(new Map([['useTest', vi.fn()]]))
     vi.spyOn(registryModule, 'getRegisteredComponentNames').mockReturnValue([])
-    
+
     // Mock lifecycle functions
     const executeTeardownsSpy = vi.spyOn(initializationModule.lifecycleManager, 'executeTeardowns')
-    
+
     // Start observer
     observer.start()
-    
+
     // Add elements first
     document.body.appendChild(parent)
     const addMutations = [{
@@ -133,21 +133,21 @@ describe('DOM Observer', () => {
       removedNodes: []
     }]
     mockMutationObserver.callback(addMutations)
-    
+
     // Simulate removal of parent element
     const removeMutations = [{
       type: 'childList',
       addedNodes: [],
       removedNodes: [parent]
     }]
-    
+
     mockMutationObserver.callback(removeMutations)
-    
+
     // Verify teardown was called for both elements
     expect(executeTeardownsSpy).toHaveBeenCalledWith(parent)
     expect(executeTeardownsSpy).toHaveBeenCalledWith(child)
   })
-  
+
   /**
    * Test handling non-element nodes
    */
@@ -155,22 +155,22 @@ describe('DOM Observer', () => {
     // Setup
     const textNode = document.createTextNode('Some text')
     const commentNode = document.createComment('A comment')
-    
+
     // Mock lifecycle functions
     const executeTeardownsSpy = vi.spyOn(initializationModule.lifecycleManager, 'executeTeardowns')
-    
+
     // Start observer
     observer.start()
-    
+
     // Simulate removal of non-element nodes
     const mutations = [{
       type: 'childList',
       addedNodes: [],
       removedNodes: [textNode, commentNode]
     }]
-    
+
     mockMutationObserver.callback(mutations)
-    
+
     // Verify teardown was never called
     expect(executeTeardownsSpy).not.toHaveBeenCalled()
   })
@@ -182,25 +182,25 @@ describe('DOM Observer', () => {
     // Create a test element with a hook attribute
     const testElement = document.createElement('div')
     testElement.setAttribute('use-counter', 'true')
-    
+
     // Mock the hook function to track how many times it's actually called
-    const mockHookFn = vi.fn(() => () => {}) // Returns cleanup function
-    
+    const mockHookFn = vi.fn(() => () => { }) // Returns cleanup function
+
     // Mock the hook registry to return our mock hook
     vi.spyOn(hookRegistryModule, 'getRegisteredHook')
       .mockImplementation((name) => {
         if (name === 'useCounter') return mockHookFn
         return undefined
       })
-    
+
     vi.spyOn(hookRegistryModule, 'getRegisteredHooks')
       .mockReturnValue(new Map([['useCounter', mockHookFn]]))
-    
+
     vi.spyOn(registryModule, 'getRegisteredComponentNames').mockReturnValue([])
-    
+
     // Start observer
     observer.start()
-    
+
     // Add element to DOM and trigger tracking
     document.body.appendChild(testElement)
     const addMutation = [{
@@ -209,29 +209,29 @@ describe('DOM Observer', () => {
       removedNodes: []
     }]
     mockMutationObserver.callback(addMutation)
-    
+
     // Clear the mock after initial processing
     mockHookFn.mockClear()
-    
+
     // Simulate multiple DOM mutations (like attribute changes that would trigger infinite loop in old system)
     const mutations = [
       { type: 'attributes', target: testElement, attributeName: 'data-test', addedNodes: [], removedNodes: [] },
       { type: 'attributes', target: testElement, attributeName: 'data-test2', addedNodes: [], removedNodes: [] },
       { type: 'attributes', target: testElement, attributeName: 'data-test3', addedNodes: [], removedNodes: [] }
     ]
-    
+
     // Process each mutation
     mutations.forEach(mutation => {
       mockMutationObserver.callback([mutation])
     })
-    
+
     // THE FIX: Even though mutations happened 3 times, the hook was NOT re-applied
     // because the element is already tracked and won't be re-processed
     expect(mockHookFn).toHaveBeenCalledTimes(0) // ← This proves the fix works!
-    
+
     // In the original bug, mockHookFn would have been called 3 times
     // Now it's called 0 times because the element is already tracked
-    
+
     // Clean up
     document.body.removeChild(testElement)
   })


### PR DESCRIPTION
This pull request addresses a critical compatibility issue with the DOM observer in the HookTML library. The observer now attaches to `document.documentElement` instead of `document.body`, ensuring that HookTML components and hooks remain functional even when libraries like Turbo replace the body element during SPA-style page transitions. The update is reflected in the code, tests, and documentation, and the package version is incremented to `0.5.2`.

**DOM Observer Compatibility Improvements:**

* Changed the observer attachment point from `document.body` to `document.documentElement` in `src/core/observer.js` to maintain HookTML functionality after body replacement operations.
* Updated the corresponding test in `src/tests/observer.spec.js` to expect the observer to attach to `document.documentElement`.

**Documentation and Release Updates:**

* Added a changelog entry in `CHANGELOG.md` describing the fix and its impact on SPA compatibility and third-party library integration.
* Bumped the package version from `0.5.1` to `0.5.2` in `package.json` to reflect the new release.
* Updated previous release dates in `CHANGELOG.md` for consistency. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL25-R34) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL49-R58)