### PR TITLE
fix: Children Name Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2025-09-21
+
+### Fixed
+
+- **Multi-word Component Names**: Fixed children prop extraction to use kebab-case for multi-word component names
+  - Components like `SearchForm` now correctly expect `search-form-input` instead of `searchform-input`
+  - Children attributes now properly convert PascalCase component names to kebab-case
+  - Maintains backward compatibility with single-word component names
+
 ## [0.5.2] - 2025-09-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooktml",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A reactive HTML component library with hooks-based lifecycle management",
   "main": "index.js",
   "type": "module",

--- a/src/tests/children.spec.js
+++ b/src/tests/children.spec.js
@@ -5,22 +5,22 @@ test('should extract children correctly', () => {
   // Setup
   const dialog = document.createElement('div')
   dialog.classList.add('Dialog')
-  
+
   const header = document.createElement('div')
   header.setAttribute('dialog-header', '')
   dialog.appendChild(header)
-  
+
   const item1 = document.createElement('div')
   item1.setAttribute('dialog-item', '')
   dialog.appendChild(item1)
-  
+
   const item2 = document.createElement('div')
   item2.setAttribute('dialog-item', '')
   dialog.appendChild(item2)
-  
+
   // Execute
   const children = extractChildren(dialog, 'Dialog')
-  
+
   // Verify
   expect(children).toEqual({
     header,
@@ -29,26 +29,46 @@ test('should extract children correctly', () => {
   })
 })
 
+test('should handle multi-word component names with kebab-case attributes', () => {
+  const searchForm = document.createElement('form')
+  searchForm.classList.add('SearchForm')
+
+  const input = document.createElement('input')
+  input.setAttribute('search-form-input', '')
+  searchForm.appendChild(input)
+
+  const button = document.createElement('button')
+  button.setAttribute('search-form-submit', '')
+  searchForm.appendChild(button)
+
+  const children = extractChildren(searchForm, 'SearchForm')
+
+  expect(children).toEqual({
+    input,
+    submit: button
+  })
+})
+
 test('should handle nested components', () => {
   // Setup
   const outerDialog = document.createElement('div')
   outerDialog.classList.add('Dialog')
-  
+
   const header = document.createElement('div')
   header.setAttribute('dialog-header', '')
   outerDialog.appendChild(header)
-  
+
   const innerDialog = document.createElement('div')
   innerDialog.classList.add('Dialog')
   outerDialog.appendChild(innerDialog)
-  
+
   const nestedHeader = document.createElement('div')
   nestedHeader.setAttribute('dialog-header', '')
   innerDialog.appendChild(nestedHeader)
-  
+
   // Execute
   const children = extractChildren(outerDialog, 'Dialog')
-  
+
   // Verify
   expect(children).toEqual({
     header
@@ -59,26 +79,26 @@ test('should handle mixed single and multiple children', () => {
   // Setup
   const dialog = document.createElement('div')
   dialog.classList.add('Dialog')
-  
+
   const header = document.createElement('div')
   header.setAttribute('dialog-header', '')
   dialog.appendChild(header)
-  
+
   const item1 = document.createElement('div')
   item1.setAttribute('dialog-item', '')
   dialog.appendChild(item1)
-  
+
   const item2 = document.createElement('div')
   item2.setAttribute('dialog-item', '')
   dialog.appendChild(item2)
-  
+
   const footer = document.createElement('div')
   footer.setAttribute('dialog-footer', '')
   dialog.appendChild(footer)
-  
+
   // Execute
   const children = extractChildren(dialog, 'Dialog')
-  
+
   // Verify
   expect(children).toEqual({
     header,
@@ -92,32 +112,32 @@ test('should NOT extract children from nested components', () => {
   // Setup
   const outerDialog = document.createElement('div')
   outerDialog.classList.add('Dialog')
-  
+
   // Add direct child to outer dialog
   const directChild = document.createElement('div')
   directChild.setAttribute('dialog-header', '')
   outerDialog.appendChild(directChild)
-  
+
   // Create nested dialog with same component name
   const nestedDialog = document.createElement('div')
   nestedDialog.classList.add('Dialog')
   outerDialog.appendChild(nestedDialog)
-  
+
   // Add child to nested dialog with dialog-* attribute
   const nestedChild = document.createElement('div')
   nestedChild.setAttribute('dialog-footer', '')
   nestedDialog.appendChild(nestedChild)
-  
+
   // Add another level of nesting to prove depth doesn't matter
   const deepNestedContainer = document.createElement('div')
   nestedDialog.appendChild(deepNestedContainer)
-  
+
   const deepNestedChild = document.createElement('div')
   deepNestedChild.setAttribute('dialog-content', '')
   deepNestedContainer.appendChild(deepNestedChild)
-  
+
   const children = extractChildren(outerDialog, 'Dialog')
-  
+
   expect(children).toEqual({
     header: directChild
   })

--- a/src/utils/children.js
+++ b/src/utils/children.js
@@ -1,4 +1,4 @@
-import { kebabToCamel, pluralize } from './strings.js'
+import { kebabToCamel, pluralize, camelToKebab } from './strings.js'
 import { isArray, isHTMLElement } from './type-guards.js'
 import { getConfig } from '../core/config.js'
 
@@ -10,7 +10,7 @@ import { getConfig } from '../core/config.js'
  */
 export const hasSameComponent = (element, componentName) => {
   const { formattedPrefix } = getConfig()
-  return element.classList.contains(componentName) || 
+  return element.classList.contains(componentName) ||
     (isHTMLElement(element) && (
       element.getAttribute(`${formattedPrefix}use-component`) === componentName
     ))
@@ -24,7 +24,7 @@ export const hasSameComponent = (element, componentName) => {
  */
 export const addPluralizedChild = (children, key, child) => {
   const pluralKey = pluralize(key)
-  
+
   if (pluralKey in children) {
     // If the pluralized key already exists, just push the new child
     if (isArray(children[pluralKey])) {
@@ -44,13 +44,13 @@ export const addPluralizedChild = (children, key, child) => {
  */
 export const extractChildren = (element, componentName) => {
   const { formattedPrefix } = getConfig()
-  const prefix = `${formattedPrefix}${componentName.toLowerCase()}-`
+  const prefix = `${formattedPrefix}${camelToKebab(componentName)}-`
   /** @type {Record<string, Element | Element[]>} */
   const children = {}
 
   // Get all descendants
   const descendants = Array.from(element.getElementsByTagName('*'))
-  
+
   // Use some to short-circuit when the component is found
   descendants.some((child) => {
     if (hasSameComponent(child, componentName)) {

--- a/src/utils/props.js
+++ b/src/utils/props.js
@@ -24,7 +24,7 @@ export const coerceValue = (value) => {
  */
 export const extractProps = (element, componentName) => {
   const { formattedPrefix } = getConfig()
-  const prefix = `${formattedPrefix}${componentName.toLowerCase()}-`
+  const prefix = `${formattedPrefix}${camelToKebab(componentName)}-`
   const props = {}
 
   // Extract regular props


### PR DESCRIPTION
This pull request focuses on improving the handling of multi-word component names when extracting children and props, ensuring that PascalCase component names are correctly converted to kebab-case in attribute names. It also adds tests to verify this behavior and updates the version to 0.5.3.

**Multi-word component name support:**

* Updated `extractChildren` and `extractProps` in `src/utils/children.js` and `src/utils/props.js` to use the new `camelToKebab` utility, ensuring that multi-word (PascalCase) component names are converted to kebab-case for attribute matching [[1]](diffhunk://#diff-e08b687fa3f5aa7b2f17dd5b84a8a1048ad0b6abb36786c248e487859c367c68L47-R47) [[2]](diffhunk://#diff-7eca83a856eaf23d7119f831948cb8183cb9b3483427648e9943421d2090f6afL27-R27).
* Added the `camelToKebab` import to `src/utils/children.js`.

**Testing improvements:**

* Added a test in `src/tests/children.spec.js` to verify correct extraction of children for multi-word component names using kebab-case attributes.

**Documentation and versioning:**

* Updated `CHANGELOG.md` to document the fix for multi-word component names and note backward compatibility.
* Bumped the package version to 0.5.3 in `package.json`.