### PR TITLE
Add agent-facing docs and consumer skills for AI code generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,152 @@
+# HookTML — Agent Reference
+
+HookTML is a JavaScript library for adding interactive behavior to HTML without a virtual DOM, templating engine, or rendering system. It looks superficially like React (hooks, signals, `useEffect`) but operates on a fundamentally different model.
+
+## Mental Model
+
+- **HTML is the source of truth.** You never generate markup from JS. You enhance existing HTML with behaviors.
+- **Hooks are the primary abstraction.** Default to hooks — keep them generalized and reusable. Only reach for a component when you need coordinated behavior across multiple elements or are grouping several hooks. This is the opposite of React, where components come first.
+- **Hooks and components initialize once per element — but the system IS reactive.** The function itself never re-runs (no re-renders), but reactivity comes from two sources: (1) signals + effects for state-driven updates, and (2) a MutationObserver that automatically initializes new elements, re-runs hooks when attributes change, and triggers cleanup when elements are removed.
+- **Signals update the DOM directly** via effects — there is no diffing or reconciliation.
+
+## Critical Differences from React
+
+| React | HookTML |
+|-------|---------|
+| JSX generates DOM | HTML already exists; JS enhances it |
+| `useState` triggers re-render | `signal()` triggers subscribed effects only |
+| Hooks run every render | Hooks run once at initialization |
+| Components are functions that return JSX | Components are functions that receive `(el, props)` and mutate the DOM |
+| Children via JSX nesting | Children via prefixed attributes (`dialog-close`, `tabs-panel`) |
+| `useEffect` cleanup on every dep change | `useEffect` runs when signal deps change; cleanup on element removal |
+
+## How Components Bind
+
+Components bind to DOM elements in one of two ways:
+
+```html
+<!-- By class name (preferred) -->
+<section class="Counter">...</section>
+
+<!-- By attribute -->
+<section use-component="Counter">...</section>
+```
+
+The component function is `(el, props) => cleanup | { cleanup, context }`.
+
+## How Children Work
+
+Child elements are identified by prefixed attributes, not by nesting or selectors:
+
+```html
+<section class="Dialog">
+  <header dialog-header>Title</header>
+  <button dialog-close>×</button>
+</section>
+```
+
+In JS: `const { header, close } = props.children;`
+
+Both singular and plural keys are always available:
+- `props.children.close` → first matching element
+- `props.children.closes` → array of all matching elements
+
+## How Hooks Bind
+
+Hooks attach via `use-*` attributes on any element:
+
+```html
+<button use-tooltip="Save your work" tooltip-placement="top">Save</button>
+```
+
+The hook function is `(el, props) => cleanup?` where props are derived from attributes:
+```js
+// props = { value: "Save your work", placement: "top" }
+```
+
+Hook name maps to function name: `use-focus-ring` → `useFocusRing`.
+
+## Signals (Not useState)
+
+```js
+const count = signal(0);
+
+// Read
+count.value;
+
+// Write — directly triggers subscribed effects
+count.value = 5;
+
+// Derived/computed
+const double = computed(() => count.value * 2);
+```
+
+Signals are NOT component-scoped. They are standalone reactive primitives that can be created anywhere.
+
+**Important:** `useEffect` only works inside a hook or component context (during initialization). It will warn and no-op if called at module scope. Signals themselves (`signal()`, `computed()`) can be created anywhere.
+
+## Utility Hooks
+
+All utility hooks accept a single element OR an array of elements:
+
+```js
+useText(el, () => `Count: ${count.value}`, [count]);
+useClasses(el, { active: isActive });
+useAttributes(el, { 'aria-expanded': isOpen });
+useStyles(el, { opacity: level });
+useEvents(el, { click: handler });
+useChildren(el, "prefix");
+```
+
+When passed an array, value functions receive `(element, index)`.
+
+## Chainable API
+
+```js
+import { with as withEl } from 'hooktml';
+
+withEl(el)
+  .useEvents({ click: handler })
+  .useClasses({ active: isActive })
+  .useAttributes({ 'aria-expanded': isOpen });
+```
+
+## Registration
+
+```js
+import { start, registerComponent, registerHook } from 'hooktml';
+
+registerComponent(MyComponent);  // name derived from function name
+registerHook(useMyHook);         // name derived from function name
+start();
+```
+
+## Common Mistakes
+
+1. **Writing JSX or returning markup.** HookTML components never return HTML. They receive an existing DOM element and attach behavior to it.
+
+2. **Expecting re-renders.** Signal changes only trigger subscribed `useEffect` callbacks and utility hooks with that signal in their deps. The component function itself never re-runs.
+
+3. **Using `useState`.** There is no `useState`. Use `signal()` for reactive state.
+
+4. **Querying children with selectors.** Use `props.children` (in components) or `useChildren(el, prefix)` (in hooks). Children are identified by prefixed attributes, not CSS selectors.
+
+5. **Treating cleanup like React's useEffect cleanup.** Cleanup runs once when the element is removed from the DOM, not on every effect re-run.
+
+6. **Forgetting to register.** Components and hooks must be registered before `start()` is called (or before the element appears in the DOM if using the mutation observer).
+
+## File Structure
+
+```
+hooktml/
+├── src/core/       — runtime, observer, signals, registry
+├── src/hooks/      — useEvents, useClasses, useAttributes, useStyles, useText, useChildren
+├── src/utils/      — helpers (props parsing, string utils, type guards)
+├── index.js        — Node entry (ESM)
+├── index.browser.js — Browser entry (ESM)
+├── index.global.js  — Global/IIFE entry (for script tags)
+```
+
+## Public Exports
+
+`start`, `scan`, `registerComponent`, `registerHook`, `registerChainableHook`, `signal`, `computed`, `useEffect`, `useChildren`, `useEvents`, `useClasses`, `useAttributes`, `useStyles`, `useText`, `with`, `getConfig`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-06-12
+
+### Added
+
+- **Agent-facing documentation (`AGENTS.md`)**: Comprehensive reference for AI agents working in consumer projects that use HookTML — covers mental model, React-vs-HookTML differences, API surface, and common mistakes
+- **Consumer skill (`skills/hooktml/SKILL.md`)**: Claude Code skill consumers can copy into their projects for accurate HookTML code generation
+- **Stimulus migration skill (`skills/hooktml-migrate-stimulus/SKILL.md`)**: Step-by-step guide for agents converting Stimulus controllers to HookTML hooks/components
+
+### Fixed
+
+- **Chainable API docs**: Removed nonexistent `.cleanup()` method from README examples — the chain returns itself from every method; individual hooks handle cleanup automatically
+
 ## [0.6.0] - 2025-10-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -790,8 +790,7 @@ with(el)
   .useEvents({ click: onClick })
   .useClasses({ active: isActive })
   .useAttributes({ "aria-expanded": isOpen })
-  .useText(() => `Hello ${firstName}`)
-  .cleanup();
+  .useText(() => `Hello ${firstName}`);
 ```
 
 ### Chainable Hooks
@@ -809,8 +808,7 @@ export const useTooltip = (el, { value }) => {
     .useClasses({
       "tooltip-visible": true,
       "text-sm": true
-    })
-    .cleanup();
+    });
 };
 ```
 
@@ -1096,8 +1094,7 @@ export const useTooltip = (el, { value }) => {
     .useClasses({
       "tooltip-visible": true,
       "text-sm": true
-    })
-    .cleanup();
+    });
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooktml",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A reactive HTML component library with hooks-based lifecycle management",
   "main": "index.js",
   "type": "module",
@@ -40,7 +40,9 @@
     "src/utils/",
     "src/index.js",
     "dist/",
-    "README.md"
+    "README.md",
+    "AGENTS.md",
+    "skills/"
   ],
   "scripts": {
     "build": "esbuild index.global.js --bundle --format=iife --outfile=dist/hooktml.min.js --minify",

--- a/skills/hooktml-migrate-stimulus/SKILL.md
+++ b/skills/hooktml-migrate-stimulus/SKILL.md
@@ -1,0 +1,109 @@
+# Migrate Stimulus to HookTML
+
+## When to use
+
+When converting a Stimulus controller to HookTML, or when the user asks to migrate, port, or rewrite Stimulus code to use HookTML.
+
+## Instructions
+
+### Concept mapping
+
+| Stimulus | HookTML |
+|----------|---------|
+| Controller class | Hook function (prefer) or Component function |
+| `targets` | `useChildren(el, prefix)` or `props.children` |
+| `values` | `signal()` |
+| `classes` | `useClasses(el, classMap, [deps])` |
+| `connect()` | The hook/component function body (runs on init) |
+| `disconnect()` | The returned cleanup function |
+| `this.element` | `el` (first argument) |
+| `data-controller="name"` | `use-name` (for hooks) or `class="Name"` (for components) |
+| `data-name-target="x"` | `name-x` attribute on the child element |
+| `data-action="click->name#method"` | `useEvents(el, { click: handler })` |
+| `data-name-value-value="x"` | `signal(x)` initialized from `props.value` |
+
+### Decision: hook or component?
+
+**Default to a hook.** Convert to a hook unless:
+- The controller coordinates 3+ distinct child element types that share state
+- The controller has complex inter-element communication
+- The behavior is specific to one context and unlikely to be reused
+
+Most Stimulus controllers map to hooks because they attach behavior to a single root element with a few targets.
+
+### Migration pattern
+
+**Stimulus controller:**
+```js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["output", "button"]
+  static values = { count: { type: Number, default: 0 } }
+
+  connect() {
+    this.render()
+  }
+
+  increment() {
+    this.countValue++
+    this.render()
+  }
+
+  render() {
+    this.outputTarget.textContent = this.countValue
+  }
+}
+```
+
+**HookTML hook equivalent:**
+```js
+import { signal, useText, useEvents, useChildren, registerHook } from 'hooktml'
+
+export const useCounter = (el, props) => {
+  const { output, button } = useChildren(el, "counter")
+  const count = signal(props.value ?? 0)
+
+  useText(output, () => `${count.value}`, [count])
+  useEvents(button, { click: () => count.value++ })
+
+  return () => count.destroy()
+}
+
+registerHook(useCounter)
+```
+
+**HTML before:**
+```html
+<div data-controller="counter" data-counter-count-value="0">
+  <span data-counter-target="output">0</span>
+  <button data-action="click->counter#increment" data-counter-target="button">+</button>
+</div>
+```
+
+**HTML after:**
+```html
+<div use-counter="0">
+  <span counter-output>0</span>
+  <button counter-button>+</button>
+</div>
+```
+
+### Migration steps
+
+1. Identify targets → these become children accessed via `useChildren(el, prefix)`
+2. Identify values → these become `signal()` calls, initialized from `props`
+3. Identify actions → these become `useEvents()` calls
+4. Identify `connect()` body → this becomes the hook function body
+5. Identify `disconnect()` → this becomes the returned cleanup function
+6. Remove class structure — flatten into a named arrow function
+7. Replace imperative DOM updates (`this.outputTarget.textContent = ...`) with declarative hooks (`useText`, `useClasses`, `useAttributes`)
+8. Register with `registerHook(useMyHook)` or `registerComponent(MyComponent)`
+
+### Common pitfalls
+
+- **Don't keep the class.** HookTML hooks are plain functions, not classes.
+- **Don't manually update DOM in response to state.** Use `useText`/`useClasses`/`useAttributes` with signal deps instead of imperative `render()` methods.
+- **Don't forget to register.** Stimulus auto-discovers controllers; HookTML requires explicit `registerHook()` or `registerComponent()`.
+- **Don't use `data-action` syntax.** Replace with `useEvents()` inside the hook.
+- **Don't use `export default`.** Use named exports for consistency.

--- a/skills/hooktml/SKILL.md
+++ b/skills/hooktml/SKILL.md
@@ -1,0 +1,107 @@
+# HookTML Usage
+
+## When to use
+
+When writing or modifying code that uses the `hooktml` library — components, hooks, signals, or HTML with `use-*` attributes or component class bindings.
+
+## Instructions
+
+HookTML is NOT React. It enhances existing HTML with behavior — no JSX, no virtual DOM, no re-renders.
+
+### Core rules
+
+1. **Hooks first, components second.** Default to writing hooks. Keep them generalized and reusable. Only create a component when you need very specific coordinated behavior across multiple elements, or when a component is essentially a group of hooks. This keeps HTML lean — unlike React, hooks are the primary unit of abstraction.
+2. **Never generate HTML from JS.** Components receive a DOM element (`el`) and attach behavior. They never return markup.
+3. **Components and hooks initialize once per element — but the system is fully reactive.** The component/hook function itself never re-runs (no re-renders), but signals + effects provide fine-grained reactivity, and a MutationObserver automatically initializes new elements, updates hooks when attributes change, and runs cleanup when elements are removed.
+4. **Use `signal()`, not `useState`.** Signals are standalone reactive primitives. Write with `.value =`, read with `.value`.
+5. **Children are attribute-based.** In a component named `Dialog`, child elements have attributes like `dialog-header`, `dialog-close`. Access them via `props.children.header`, `props.children.close`.
+6. **Hooks bind via `use-*` attributes.** `use-tooltip="text"` calls `useTooltip(el, { value: "text" })`. Additional props come from matching prefixed attributes (`tooltip-placement="top"` → `props.placement`).
+
+### Patterns
+
+**Component:**
+```js
+import { signal, useText, useEvents, registerComponent } from 'hooktml';
+
+export const Counter = (el, props) => {
+  const { increment, display } = props.children;
+  const count = signal(0);
+
+  useText(display, () => `${count.value}`, [count]);
+  useEvents(increment, { click: () => count.value += 1 });
+
+  return () => count.destroy();
+};
+
+registerComponent(Counter);
+```
+
+```html
+<section class="Counter">
+  <button counter-increment>+</button>
+  <span counter-display>0</span>
+</section>
+```
+
+**Hook:**
+```js
+import { useEvents, registerHook } from 'hooktml';
+
+export const useCopyToClipboard = (el, props) => {
+  useEvents(el, {
+    click: () => navigator.clipboard.writeText(props.value || el.textContent)
+  });
+};
+
+registerHook(useCopyToClipboard);
+```
+
+```html
+<code use-copy-to-clipboard="secret-text">Click to copy</code>
+```
+
+**Signals + computed (inside a hook or component):**
+```js
+import { signal, computed, useEffect } from 'hooktml';
+
+export const useItemCounter = (el, props) => {
+  const items = signal([]);
+  const count = computed(() => items.value.length);
+
+  useEffect(() => {
+    el.textContent = `${count.value} items`;
+  }, [count]);
+};
+```
+
+Note: `useEffect` only works inside a hook/component context. It will warn and no-op if called at module scope.
+
+**Utility hooks (single or array of elements):**
+```js
+useClasses(buttons, { active: (btn, i) => i === selected.value }, [selected]);
+useAttributes(el, { 'aria-expanded': isOpen });
+useStyles(cards, { opacity: (card, i) => i === active.value ? 1 : 0.3 }, [active]);
+useText(el, () => `Hello ${name.value}`, [name]);
+useEvents(el, { click: handler });
+```
+
+**Chainable API:**
+```js
+import { with as withEl } from 'hooktml';
+
+withEl(el)
+  .useEvents({ click: handler })
+  .useClasses({ active: isActive })
+  .useAttributes({ 'aria-expanded': isOpen });
+```
+
+The chain returns itself from every method — there is no `.cleanup()` terminator. Individual hooks handle their own cleanup automatically.
+
+### What NOT to do
+
+- Don't return JSX or HTML strings from components
+- Don't use `useState`, `useRef`, `useMemo`, or other React hooks
+- Don't expect component functions to re-run
+- Don't query children with `querySelector` — use `props.children` or `useChildren(el, prefix)`
+- Don't forget to register components/hooks before `start()`
+- Don't add signals to deps arrays as `.value` — pass the signal object itself: `[count]` not `[count.value]`


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` — a comprehensive reference shipped in the npm package so AI agents in consumer projects understand HookTML's model (not React) and generate correct code
- Add `skills/hooktml/SKILL.md` — a Claude Code skill consumers can copy into `.claude/skills/` for accurate HookTML code generation
- Add `skills/hooktml-migrate-stimulus/SKILL.md` — a migration guide skill for converting Stimulus controllers to HookTML hooks
- Fix `.cleanup()` references in README chainable API examples (method doesn't exist on the chain)
- Bump version to 0.6.1

## Test plan

- [x] `npm pack --dry-run` confirms new files are included in the package
- [ ] Verify AGENTS.md content matches actual library behavior
- [ ] Verify skill examples run correctly inside a hook/component context


🤖 Generated with [Claude Code](https://claude.com/claude-code)