### PR TITLE
Fix publish workflow: use yarn and upgrade to Node 22

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,41 @@
+name: PR Version & Changelog Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Check version bump
+        run: |
+          PR_VERSION=$(node -p "require('./package.json').version")
+          MAIN_VERSION=$(git show origin/main:package.json | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version")
+          echo "PR version: $PR_VERSION"
+          echo "main version: $MAIN_VERSION"
+          if [ "$PR_VERSION" = "$MAIN_VERSION" ]; then
+            echo "::error::package.json version ($PR_VERSION) has not been bumped from main"
+            exit 1
+          fi
+
+      - name: Check changelog entry
+        run: |
+          PR_VERSION=$(node -p "require('./package.json').version")
+          if ! grep -qE "^## \[$PR_VERSION\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing a ## [$PR_VERSION] entry"
+            exit 1
+          fi
+          if git show origin/main:CHANGELOG.md | grep -qE "^## \[$PR_VERSION\]"; then
+            echo "::error::CHANGELOG.md ## [$PR_VERSION] entry already exists on main (not a new entry)"
+            exit 1
+          fi
+          echo "Found new changelog entry for version $PR_VERSION"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
 
       - name: Check if version already published
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.check.outputs.skip == 'false'
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Run tests
         if: steps.check.outputs.skip == 'false'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.2] - 2026-06-20
+## [0.6.3] - 2026-06-20
 
 ### Fixed
 
-- **Publish workflow**: Added `workflow_dispatch` trigger so the publish workflow can be manually run from the GitHub Actions UI as a fallback
+- **CI workflows**: Use `yarn install --frozen-lockfile` instead of `npm ci` (repo uses yarn.lock, not package-lock.json)
+- **CI workflows**: Upgrade Node.js from 20 to 22 to resolve deprecation warnings
+- **Publish workflow**: Added `workflow_dispatch` trigger for manual runs from the GitHub Actions UI
 
 ## [0.6.1] - 2026-06-12
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooktml",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A reactive HTML component library with hooks-based lifecycle management",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

- Fix `npm ci` → `yarn install --frozen-lockfile` (repo uses yarn.lock, not package-lock.json)
- Upgrade Node.js from 20 to 22 to resolve deprecation warnings
- Add `pr-check.yml` workflow for version/changelog enforcement
- Bump to 0.6.3

Previous merge (#10) landed before this fix was pushed, so the publish workflow on main is still broken.

## Test plan

- [ ] Merge this PR
- [ ] Confirm the publish workflow passes and publishes 0.6.3 to npm
- [ ] Re-add `version-check` as a required status check in the branch ruleset

🤖 Generated with [Claude Code](https://claude.com/claude-code)